### PR TITLE
Message types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ an endpoint, either the client or the server. You write your code against this i
 the Bevy plugin which provides events used by the transport), and you don't have to worry about the
 underlying mechanism used to transport your data.
 
-# Meet the transports
+# Transports
 
-Currently aeronet supports:
-* [`aeronet_wt_native`](https://docs.rs/aeronet_wt_native): a transport implemented on top of the
-  WebTransport protocol, which is in turn implemented on top of QUIC. The transport has native
-  client and server implementations using [`wtransport`](https://docs.rs/wtransport), and a WASM
-  client implementation using [`web-sys`](https://docs.rs/web-sys).
+* [`aeronet_channel`](https://docs.rs/aeronet_channel) using in-memory MPSC channels, useful for
+  local singleplayer servers
+* [`aeronet_wt_native`](https://docs.rs/aeronet_wt_native) using the
+  [WebTransport](https://developer.chrome.com/en/articles/webtransport/), useful for a generic
+  client-server architecture with support for WASM clients

--- a/aeronet_channel/src/client/mod.rs
+++ b/aeronet_channel/src/client/mod.rs
@@ -1,5 +1,5 @@
 use aeronet::ClientTransportConfig;
-use crossbeam_channel::{Sender, Receiver};
+use crossbeam_channel::{Receiver, Sender};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy", derive(bevy::prelude::Resource))]

--- a/aeronet_channel/src/client/mod.rs
+++ b/aeronet_channel/src/client/mod.rs
@@ -1,9 +1,8 @@
-use aeronet::ClientTransportConfig;
 use crossbeam_channel::{Receiver, Sender};
 
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy", derive(bevy::prelude::Resource))]
-pub struct ChannelTransportClient<C: ClientTransportConfig> {
-    pub(crate) send: Sender<C::C2S>,
-    pub(crate) recv: Receiver<C::S2C>,
+pub struct ChannelTransportClient<C2S, S2C> {
+    pub(crate) send: Sender<C2S>,
+    pub(crate) recv: Receiver<S2C>,
 }

--- a/aeronet_channel/src/lib.rs
+++ b/aeronet_channel/src/lib.rs
@@ -6,5 +6,5 @@ mod client;
 mod server;
 mod shared;
 
-pub use server::ChannelTransportServer;
 pub use client::ChannelTransportClient;
+pub use server::ChannelTransportServer;

--- a/aeronet_channel/src/server/mod.rs
+++ b/aeronet_channel/src/server/mod.rs
@@ -1,22 +1,27 @@
-use aeronet::{ClientId, RecvError, ServerEvent, ServerTransport, ServerTransportConfig};
+use aeronet::{ClientId, RecvError, ServerEvent, ServerTransport, Message};
 use crossbeam_channel::{Receiver, Sender};
 use rustc_hash::FxHashMap;
 
 use crate::{shared::CHANNEL_BUF, ChannelTransportClient};
 
-struct ClientInfo<C: ServerTransportConfig> {
-    send: Sender<C::S2C>,
-    recv: Receiver<C::C2S>,
+#[derive(Debug)]
+struct ClientInfo<C2S, S2C> {
+    send: Sender<S2C>,
+    recv: Receiver<C2S>,
 }
 
 #[derive(Debug)]
 #[cfg_attr(feature = "bevy", derive(bevy::prelude::Resource))]
-pub struct ChannelTransportServer<C: ServerTransportConfig> {
-    clients: FxHashMap<ClientId, ClientInfo<C>>,
+pub struct ChannelTransportServer<C2S, S2C> {
+    clients: FxHashMap<ClientId, ClientInfo<C2S, S2C>>,
     next_client: usize,
 }
 
-impl<C: ServerTransportConfig> ChannelTransportServer<C> {
+impl<C2S, S2C> ChannelTransportServer<C2S, S2C>
+where
+    C2S: Message,
+    S2C: Message,
+{
     pub fn new() -> Self {
         Self {
             clients: FxHashMap::default(),
@@ -24,9 +29,9 @@ impl<C: ServerTransportConfig> ChannelTransportServer<C> {
         }
     }
 
-    pub fn connect(&mut self) -> (ClientId, ChannelTransportClient<C>) {
-        let (send_c2s, recv_c2s) = crossbeam_channel::bounded::<C::C2S>(CHANNEL_BUF);
-        let (send_s2c, recv_s2c) = crossbeam_channel::bounded::<C::S2C>(CHANNEL_BUF);
+    pub fn connect(&mut self) -> (ClientId, ChannelTransportClient<C2S, S2C>) {
+        let (send_c2s, recv_c2s) = crossbeam_channel::bounded::<C2S>(CHANNEL_BUF);
+        let (send_s2c, recv_s2c) = crossbeam_channel::bounded::<S2C>(CHANNEL_BUF);
 
         let client_id = ClientId::from_raw(self.next_client);
         self.next_client += 1;
@@ -36,7 +41,7 @@ impl<C: ServerTransportConfig> ChannelTransportServer<C> {
             recv: recv_s2c,
         };
         let our_client = ClientInfo {
-            send: send_c2s,
+            send: send_s2c,
             recv: recv_c2s,
         };
         self.clients.insert(client_id, our_client);
@@ -44,14 +49,18 @@ impl<C: ServerTransportConfig> ChannelTransportServer<C> {
     }
 }
 
-impl<C: ServerTransportConfig> ServerTransport<C> for ChannelTransportServer<C> {
+impl<C2S, S2C> ServerTransport<C2S, S2C> for ChannelTransportServer<C2S, S2C>
+where
+    C2S: Message,
+    S2C: Message,
+{
     type ClientInfo = ();
 
-    fn recv(&mut self) -> Result<ServerEvent<C::C2S>, RecvError> {
+    fn recv(&mut self) -> Result<ServerEvent<C2S>, RecvError> {
         todo!()
     }
 
-    fn send(&mut self, client: ClientId, msg: impl Into<C::S2C>) {
+    fn send(&mut self, client: ClientId, msg: impl Into<S2C>) {
         todo!()
     }
 

--- a/aeronet_wt_native/README.md
+++ b/aeronet_wt_native/README.md
@@ -3,8 +3,9 @@
 [![crates.io](https://img.shields.io/crates/v/aeronet_wt_native.svg)](https://crates.io/crates/aeronet_wt_native)
 [![docs.rs](https://img.shields.io/docsrs/aeronet_wt_native)](https://docs.rs/aeronet_wt_native)
 
-A [WebTransport](https://www.w3.org/TR/webtransport/) transport implementation of aeronet, which
-uses the QUIC protocol under the hood to provide reliable streams and unreliable datagrams.
+A [WebTransport](https://developer.chrome.com/en/articles/webtransport/) transport implementation
+of aeronet, which uses the QUIC protocol under the hood to provide reliable streams and unreliable
+datagrams.
 
 This transport can be used in a native app to provide a client and server transport using
 [`wtransport`](https://docs.rs/wtransport) as the WebTransport protocol implementation

--- a/aeronet_wt_native/examples/echo_client.rs
+++ b/aeronet_wt_native/examples/echo_client.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use aeronet::{
     AsyncRuntime, ClientTransportConfig, ClientTransportPlugin, LocalClientConnected,
-    LocalClientDisconnected, RecvMessage, SendMessage,
+    LocalClientDisconnected, RecvMessage, TryIntoBytes,
 };
 use aeronet_wt_native::{
     wtransport::ClientConfig, ClientStream, StreamMessage, TransportStreams, WebTransportClient,
@@ -22,7 +22,7 @@ impl ClientTransportConfig for AppTransportConfig {
 #[derive(Debug, Clone)]
 pub struct AppMessage(pub String);
 
-impl SendMessage for AppMessage {
+impl TryIntoBytes for AppMessage {
     fn into_payload(self) -> Result<Vec<u8>> {
         Ok(self.0.into_bytes())
     }

--- a/aeronet_wt_native/examples/echo_client.rs
+++ b/aeronet_wt_native/examples/echo_client.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use aeronet::{
-    AsyncRuntime, ClientTransportConfig, ClientTransportPlugin, LocalClientConnected,
-    LocalClientDisconnected, RecvMessage, TryIntoBytes,
+    AsyncRuntime, ClientTransportPlugin, LocalClientConnected, LocalClientDisconnected,
+    TryFromBytes, TryIntoBytes,
 };
 use aeronet_wt_native::{
     wtransport::ClientConfig, ClientStream, StreamMessage, TransportStreams, WebTransportClient,
@@ -12,29 +12,24 @@ use bevy::{log::LogPlugin, prelude::*};
 
 // config
 
-pub struct AppTransportConfig;
-
-impl ClientTransportConfig for AppTransportConfig {
-    type C2S = StreamMessage<ClientStream, AppMessage>;
-    type S2C = AppMessage;
-}
-
 #[derive(Debug, Clone)]
 pub struct AppMessage(pub String);
 
 impl TryIntoBytes for AppMessage {
-    fn into_payload(self) -> Result<Vec<u8>> {
+    fn try_into_bytes(self) -> Result<Vec<u8>> {
         Ok(self.0.into_bytes())
     }
 }
 
-impl RecvMessage for AppMessage {
-    fn from_payload(payload: &[u8]) -> Result<Self> {
+impl TryFromBytes for AppMessage {
+    fn try_from_bytes(payload: &[u8]) -> Result<Self> {
         String::from_utf8(payload.to_owned().into_iter().collect())
             .map(|s| AppMessage(s))
             .map_err(|err| err.into())
     }
 }
+
+type Client = WebTransportClient<StreamMessage<ClientStream, AppMessage>, AppMessage>;
 
 // logic
 
@@ -45,7 +40,7 @@ fn main() {
                 level: tracing::Level::DEBUG,
                 ..default()
             }),
-            ClientTransportPlugin::<AppTransportConfig, WebTransportClient<_>>::default(),
+            ClientTransportPlugin::<_, _, Client>::default(),
         ))
         .init_resource::<AsyncRuntime>()
         .add_systems(Startup, setup)
@@ -63,7 +58,7 @@ fn setup(mut commands: Commands, rt: Res<AsyncRuntime>) {
     }
 }
 
-fn create(rt: &AsyncRuntime) -> Result<WebTransportClient<AppTransportConfig>> {
+fn create(rt: &AsyncRuntime) -> Result<Client> {
     let config = ClientConfig::builder()
         .with_bind_default()
         .with_no_cert_validation()

--- a/aeronet_wt_native/examples/echo_server.rs
+++ b/aeronet_wt_native/examples/echo_server.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use aeronet::{
-    AsyncRuntime, FromClient, MessageTypes, RemoteClientDisconnected, ServerTransport,
-    ServerTransportPlugin, TryIntoBytes,
+    AsyncRuntime, FromClient, RemoteClientDisconnected, ServerTransport, ServerTransportPlugin,
+    TryFromBytes, TryIntoBytes,
 };
 use aeronet_wt_native::{
     wtransport::{tls::Certificate, ServerConfig},
@@ -17,29 +17,24 @@ use bevy::{
 
 // config
 
-pub struct AppMessageTypes;
-
-impl MessageTypes for AppMessageTypes {
-    type C2S = AppMessage;
-    type S2C = StreamMessage<ServerStream, AppMessage>;
-}
-
 #[derive(Debug, Clone)]
 pub struct AppMessage(pub String);
 
 impl TryIntoBytes for AppMessage {
-    fn into_payload(self) -> Result<Vec<u8>> {
+    fn try_into_bytes(self) -> Result<Vec<u8>> {
         Ok(self.0.into_bytes())
     }
 }
 
-impl RecvMessage for AppMessage {
-    fn from_payload(payload: &[u8]) -> Result<Self> {
+impl TryFromBytes for AppMessage {
+    fn try_from_bytes(payload: &[u8]) -> Result<Self> {
         String::from_utf8(payload.to_owned().into_iter().collect())
             .map(|s| AppMessage(s))
             .map_err(|err| err.into())
     }
 }
+
+type Server = WebTransportServer<AppMessage, StreamMessage<ServerStream, AppMessage>>;
 
 // logic
 
@@ -53,7 +48,7 @@ fn main() {
                 level: tracing::Level::DEBUG,
                 ..default()
             },
-            ServerTransportPlugin::<AppMessageTypes, WebTransportServer<_>>::default(),
+            ServerTransportPlugin::<_, _, Server>::default(),
         ))
         .init_resource::<AsyncRuntime>()
         .add_systems(Startup, setup)
@@ -71,7 +66,7 @@ fn setup(mut commands: Commands, rt: Res<AsyncRuntime>) {
     }
 }
 
-fn create(rt: &AsyncRuntime) -> Result<WebTransportServer<AppMessageTypes>> {
+fn create(rt: &AsyncRuntime) -> Result<Server> {
     let cert = Certificate::load(
         "./aeronet_wt_native/examples/cert.pem",
         "./aeronet_wt_native/examples/key.pem",
@@ -91,7 +86,7 @@ fn create(rt: &AsyncRuntime) -> Result<WebTransportServer<AppMessageTypes>> {
 }
 
 fn reply(
-    mut server: ResMut<WebTransportServer<AppMessageTypes>>,
+    mut server: ResMut<Server>,
     mut recv: EventReader<FromClient<AppMessage>>,
     mut exit: EventWriter<AppExit>,
 ) {
@@ -109,10 +104,7 @@ fn reply(
     }
 }
 
-fn log_disconnect(
-    server: Res<WebTransportServer<AppMessageTypes>>,
-    mut dc: EventReader<RemoteClientDisconnected>,
-) {
+fn log_disconnect(server: Res<Server>, mut dc: EventReader<RemoteClientDisconnected>) {
     for RemoteClientDisconnected { client, reason } in dc.iter() {
         info!(
             "Client {client} disconnected: {:#}",

--- a/aeronet_wt_native/examples/echo_server.rs
+++ b/aeronet_wt_native/examples/echo_server.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use aeronet::{
-    AsyncRuntime, FromClient, RecvMessage, RemoteClientDisconnected, ServerTransport,
-    ServerTransportConfig, ServerTransportPlugin, TryIntoBytes,
+    AsyncRuntime, FromClient, RemoteClientDisconnected, ServerTransport,
+    ServerTransportPlugin, TryIntoBytes, MessageTypes,
 };
 use aeronet_wt_native::{
     wtransport::{tls::Certificate, ServerConfig},
@@ -17,9 +17,9 @@ use bevy::{
 
 // config
 
-pub struct AppTransportConfig;
+pub struct AppMessageTypes;
 
-impl ServerTransportConfig for AppTransportConfig {
+impl MessageTypes for AppMessageTypes {
     type C2S = AppMessage;
     type S2C = StreamMessage<ServerStream, AppMessage>;
 }
@@ -53,7 +53,7 @@ fn main() {
                 level: tracing::Level::DEBUG,
                 ..default()
             },
-            ServerTransportPlugin::<AppTransportConfig, WebTransportServer<_>>::default(),
+            ServerTransportPlugin::<AppMessageTypes, WebTransportServer<_>>::default(),
         ))
         .init_resource::<AsyncRuntime>()
         .add_systems(Startup, setup)
@@ -71,7 +71,7 @@ fn setup(mut commands: Commands, rt: Res<AsyncRuntime>) {
     }
 }
 
-fn create(rt: &AsyncRuntime) -> Result<WebTransportServer<AppTransportConfig>> {
+fn create(rt: &AsyncRuntime) -> Result<WebTransportServer<AppMessageTypes>> {
     let cert = Certificate::load(
         "./aeronet_wt_native/examples/cert.pem",
         "./aeronet_wt_native/examples/key.pem",
@@ -91,7 +91,7 @@ fn create(rt: &AsyncRuntime) -> Result<WebTransportServer<AppTransportConfig>> {
 }
 
 fn reply(
-    mut server: ResMut<WebTransportServer<AppTransportConfig>>,
+    mut server: ResMut<WebTransportServer<AppMessageTypes>>,
     mut recv: EventReader<FromClient<AppMessage>>,
     mut exit: EventWriter<AppExit>,
 ) {
@@ -110,7 +110,7 @@ fn reply(
 }
 
 fn log_disconnect(
-    server: Res<WebTransportServer<AppTransportConfig>>,
+    server: Res<WebTransportServer<AppMessageTypes>>,
     mut dc: EventReader<RemoteClientDisconnected>,
 ) {
     for RemoteClientDisconnected { client, reason } in dc.iter() {

--- a/aeronet_wt_native/examples/echo_server.rs
+++ b/aeronet_wt_native/examples/echo_server.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use aeronet::{
-    AsyncRuntime, FromClient, RemoteClientDisconnected, ServerTransport,
-    ServerTransportPlugin, TryIntoBytes, MessageTypes,
+    AsyncRuntime, FromClient, MessageTypes, RemoteClientDisconnected, ServerTransport,
+    ServerTransportPlugin, TryIntoBytes,
 };
 use aeronet_wt_native::{
     wtransport::{tls::Certificate, ServerConfig},

--- a/aeronet_wt_native/examples/echo_server.rs
+++ b/aeronet_wt_native/examples/echo_server.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 use aeronet::{
-    AsyncRuntime, FromClient, RecvMessage, RemoteClientDisconnected, SendMessage, ServerTransport,
-    ServerTransportConfig, ServerTransportPlugin,
+    AsyncRuntime, FromClient, RecvMessage, RemoteClientDisconnected, ServerTransport,
+    ServerTransportConfig, ServerTransportPlugin, TryIntoBytes,
 };
 use aeronet_wt_native::{
     wtransport::{tls::Certificate, ServerConfig},
@@ -27,7 +27,7 @@ impl ServerTransportConfig for AppTransportConfig {
 #[derive(Debug, Clone)]
 pub struct AppMessage(pub String);
 
-impl SendMessage for AppMessage {
+impl TryIntoBytes for AppMessage {
     fn into_payload(self) -> Result<Vec<u8>> {
         Ok(self.0.into_bytes())
     }

--- a/aeronet_wt_native/src/client/mod.rs
+++ b/aeronet_wt_native/src/client/mod.rs
@@ -1,13 +1,13 @@
 pub mod back;
 pub mod front;
 
-use aeronet::{ClientTransportConfig, SendMessage, SessionError};
+use aeronet::{MessageTypes, SessionError, TryIntoBytes};
 use tokio::sync::mpsc;
 use wtransport::{ClientConfig, Connection};
 
 use crate::{
-    ClientStream, EndpointInfo, SendOn, TransportStreams, WebTransportClient,
-    WebTransportClientBackend, shared::CHANNEL_BUF,
+    shared::CHANNEL_BUF, ClientStream, EndpointInfo, SendOn, TransportStreams, WebTransportClient,
+    WebTransportClientBackend,
 };
 
 /// Details on the server which this client is connected to through the WebTransport protocol.
@@ -38,24 +38,24 @@ impl RemoteServerInfo {
 /// once using [`WebTransportClientBackend::start`] in an async Tokio runtime when it is first
 /// available (this function does not automatically start the backend, because we have no
 /// guarantees about the current Tokio runtime at this point).
-pub fn create_client<C2S, C>(
+pub fn create_client<C2S, M>(
     config: ClientConfig,
     streams: TransportStreams,
-) -> (WebTransportClient<C>, WebTransportClientBackend<C>)
+) -> (WebTransportClient<M>, WebTransportClientBackend<M>)
 where
-    C2S: SendMessage + SendOn<ClientStream>,
-    C: ClientTransportConfig<C2S = C2S>,
+    C2S: TryIntoBytes + SendOn<ClientStream>,
+    M: MessageTypes<C2S = C2S>,
 {
-    let (send_b2f, recv_b2f) = mpsc::channel::<Event<C::S2C>>(CHANNEL_BUF);
-    let (send_f2b, recv_f2b) = mpsc::channel::<Request<C::C2S>>(CHANNEL_BUF);
+    let (send_b2f, recv_b2f) = mpsc::channel::<Event<M::S2C>>(CHANNEL_BUF);
+    let (send_f2b, recv_f2b) = mpsc::channel::<Request<M::C2S>>(CHANNEL_BUF);
 
-    let frontend = WebTransportClient::<C> {
+    let frontend = WebTransportClient::<M> {
         send: send_f2b,
         recv: recv_b2f,
         info: None,
     };
 
-    let backend = WebTransportClientBackend::<C> {
+    let backend = WebTransportClientBackend::<M> {
         config,
         streams,
         send: send_b2f,

--- a/aeronet_wt_native/src/server/back.rs
+++ b/aeronet_wt_native/src/server/back.rs
@@ -1,6 +1,6 @@
 use std::{convert::Infallible, io};
 
-use aeronet::{ClientId, ServerTransportConfig, SessionError};
+use aeronet::{ClientId, MessageTypes, SessionError};
 use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, debug_span, Instrument};
 use wtransport::{
@@ -20,14 +20,14 @@ use super::{Event, RemoteClientInfo, Request, CHANNEL_BUF};
 ///
 /// The only thing you should do with this struct is to run [`WebTransportServerBackend::start`]
 /// in an async task - the frontend will handle the rest.
-pub struct WebTransportServerBackend<C: ServerTransportConfig> {
+pub struct WebTransportServerBackend<M: MessageTypes> {
     pub(crate) config: ServerConfig,
     pub(crate) streams: TransportStreams,
-    pub(crate) send_b2f: mpsc::Sender<Event<C::C2S>>,
-    pub(crate) send_f2b: broadcast::Sender<Request<C::S2C>>,
+    pub(crate) send_b2f: mpsc::Sender<Event<M::C2S>>,
+    pub(crate) send_f2b: broadcast::Sender<Request<M::S2C>>,
 }
 
-impl<C: ServerTransportConfig> WebTransportServerBackend<C> {
+impl<M: MessageTypes> WebTransportServerBackend<M> {
     /// Starts the server logic which interfaces with clients.
     pub async fn start(self) -> Result<(), io::Error> {
         let Self {
@@ -39,17 +39,17 @@ impl<C: ServerTransportConfig> WebTransportServerBackend<C> {
 
         let endpoint = Endpoint::server(config)?;
         debug!("Started WebTransport server backend");
-        listen::<C>(endpoint, streams, send_b2f, send_f2b).await;
+        listen::<M>(endpoint, streams, send_b2f, send_f2b).await;
         debug!("Stopped WebTransport server backend");
         Ok(())
     }
 }
 
-async fn listen<C: ServerTransportConfig>(
+async fn listen<M: MessageTypes>(
     endpoint: Endpoint<Server>,
     streams: TransportStreams,
-    send_evt: mpsc::Sender<Event<C::C2S>>,
-    send_req: broadcast::Sender<Request<C::S2C>>,
+    send_evt: mpsc::Sender<Event<M::C2S>>,
+    send_req: broadcast::Sender<Request<M::S2C>>,
 ) {
     let (send_close, mut recv_close) = mpsc::channel::<()>(1);
     for client in 0.. {
@@ -69,7 +69,7 @@ async fn listen<C: ServerTransportConfig>(
 
         tokio::spawn(
             async move {
-                let reason = handle_session::<C>(streams, send.clone(), recv, client, req)
+                let reason = handle_session::<M>(streams, send.clone(), recv, client, req)
                     .await
                     .unwrap_err();
                 if send
@@ -85,19 +85,19 @@ async fn listen<C: ServerTransportConfig>(
     }
 }
 
-async fn handle_session<C: ServerTransportConfig>(
+async fn handle_session<M: MessageTypes>(
     streams: TransportStreams,
-    mut send: mpsc::Sender<Event<C::C2S>>,
-    mut recv: broadcast::Receiver<Request<C::S2C>>,
+    mut send: mpsc::Sender<Event<M::C2S>>,
+    mut recv: broadcast::Receiver<Request<M::S2C>>,
     client: ClientId,
     req: IncomingSession,
 ) -> Result<Infallible, SessionError> {
-    let mut conn = accept_session::<C>(&mut send, client, req).await?;
+    let mut conn = accept_session::<M>(&mut send, client, req).await?;
 
-    let (send_in, mut recv_in) = mpsc::channel::<C::C2S>(CHANNEL_BUF);
+    let (send_in, mut recv_in) = mpsc::channel::<M::C2S>(CHANNEL_BUF);
     let (send_err, mut recv_err) = mpsc::channel::<SessionError>(CHANNEL_BUF);
     let (mut streams_bi, mut streams_uni_out) =
-        open_streams::<C::S2C, C::C2S, ServerStream>(&streams, &mut conn, send_in, send_err)
+        open_streams::<M::S2C, M::C2S, ServerStream>(&streams, &mut conn, send_in, send_err)
             .await?;
 
     loop {
@@ -110,7 +110,7 @@ async fn handle_session<C: ServerTransportConfig>(
 
         tokio::select! {
             result = conn.receive_datagram() => {
-                let msg = recv_datagram::<C::C2S>(result)
+                let msg = recv_datagram::<M::C2S>(result)
                     .await
                     .map_err(|err| SessionError::Transport(err.on(TransportStream::Datagram).into()))?;
                 send.send(Event::Recv { client, msg })
@@ -129,7 +129,7 @@ async fn handle_session<C: ServerTransportConfig>(
                 let req = result.map_err(|_| SessionError::Closed)?;
                 match req {
                     Request::Send { client: target, stream, msg } if target == client => {
-                        send_out::<C::S2C>(&mut conn, &mut streams_bi, &mut streams_uni_out, stream.into(), msg)
+                        send_out::<M::S2C>(&mut conn, &mut streams_bi, &mut streams_uni_out, stream.into(), msg)
                             .await
                             .map_err(|err| SessionError::Transport(err.on(stream.into()).into()))?;
                     }
@@ -143,8 +143,8 @@ async fn handle_session<C: ServerTransportConfig>(
     }
 }
 
-async fn accept_session<C: ServerTransportConfig>(
-    send: &mut mpsc::Sender<Event<C::C2S>>,
+async fn accept_session<M: MessageTypes>(
+    send: &mut mpsc::Sender<Event<M::C2S>>,
     client: ClientId,
     req: IncomingSession,
 ) -> Result<Connection, SessionError> {

--- a/aeronet_wt_native/src/server/mod.rs
+++ b/aeronet_wt_native/src/server/mod.rs
@@ -3,14 +3,14 @@ pub mod front;
 
 use std::collections::HashMap;
 
-use aeronet::{ClientId, SendMessage, ServerTransportConfig, SessionError};
+use aeronet::{ClientId, MessageTypes, SessionError, TryIntoBytes};
 use rustc_hash::FxHashMap;
 use tokio::sync::{broadcast, mpsc};
 use wtransport::{endpoint::SessionRequest, Connection, ServerConfig};
 
 use crate::{
-    EndpointInfo, SendOn, ServerStream, TransportStreams, WebTransportServer,
-    WebTransportServerBackend, shared::CHANNEL_BUF,
+    shared::CHANNEL_BUF, EndpointInfo, SendOn, ServerStream, TransportStreams, WebTransportServer,
+    WebTransportServerBackend,
 };
 
 /// Details on a client which is connected to this server through the WebTransport protocol.
@@ -56,24 +56,24 @@ impl RemoteClientInfo {
 /// once using [`WebTransportServerBackend::start`] in an async Tokio runtime when it is first
 /// available (this function does not automatically start the backend, because we have no
 /// guarantees about the current Tokio runtime at this point).
-pub fn create_server<S2C, C>(
+pub fn create_server<S2C, M>(
     config: ServerConfig,
     streams: TransportStreams,
-) -> (WebTransportServer<C>, WebTransportServerBackend<C>)
+) -> (WebTransportServer<M>, WebTransportServerBackend<M>)
 where
-    S2C: SendMessage + SendOn<ServerStream>,
-    C: ServerTransportConfig<S2C = S2C>,
+    S2C: TryIntoBytes + SendOn<ServerStream>,
+    M: MessageTypes<S2C = S2C>,
 {
-    let (send_b2f, recv_b2f) = mpsc::channel::<Event<C::C2S>>(CHANNEL_BUF);
-    let (send_f2b, _) = broadcast::channel::<Request<C::S2C>>(CHANNEL_BUF);
+    let (send_b2f, recv_b2f) = mpsc::channel::<Event<M::C2S>>(CHANNEL_BUF);
+    let (send_f2b, _) = broadcast::channel::<Request<M::S2C>>(CHANNEL_BUF);
 
-    let frontend = WebTransportServer::<C> {
+    let frontend = WebTransportServer::<M> {
         send: send_f2b.clone(),
         recv: recv_b2f,
         clients: FxHashMap::default(),
     };
 
-    let backend = WebTransportServerBackend::<C> {
+    let backend = WebTransportServerBackend::<M> {
         config,
         streams,
         send_b2f,

--- a/aeronet_wt_native/src/server/mod.rs
+++ b/aeronet_wt_native/src/server/mod.rs
@@ -3,7 +3,7 @@ pub mod front;
 
 use std::collections::HashMap;
 
-use aeronet::{ClientId, MessageTypes, SessionError, TryIntoBytes};
+use aeronet::{ClientId, MessageTypes, SessionError, TryIntoBytes, Message};
 use rustc_hash::FxHashMap;
 use tokio::sync::{broadcast, mpsc};
 use wtransport::{endpoint::SessionRequest, Connection, ServerConfig};
@@ -61,7 +61,7 @@ pub fn create_server<S2C, M>(
     streams: TransportStreams,
 ) -> (WebTransportServer<M>, WebTransportServerBackend<M>)
 where
-    S2C: TryIntoBytes + SendOn<ServerStream>,
+    S2C: Message + TryIntoBytes + SendOn<ServerStream> + Clone,
     M: MessageTypes<S2C = S2C>,
 {
     let (send_b2f, recv_b2f) = mpsc::channel::<Event<M::C2S>>(CHANNEL_BUF);

--- a/aeronet_wt_native/src/shared.rs
+++ b/aeronet_wt_native/src/shared.rs
@@ -1,4 +1,4 @@
-use aeronet::{SessionError, TryFromBytes, TryIntoBytes, Message};
+use aeronet::{Message, SessionError, TryFromBytes, TryIntoBytes};
 use anyhow::Result;
 use tokio::sync::mpsc;
 use wtransport::{

--- a/aeronet_wt_native/src/transport.rs
+++ b/aeronet_wt_native/src/transport.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, time::Duration};
 
-use aeronet::{TransportRemoteAddr, TransportRtt, TryIntoBytes};
+use aeronet::{RemoteAddr, Rtt, TryIntoBytes};
 use anyhow::Result;
 use wtransport::Connection;
 
@@ -36,13 +36,13 @@ impl EndpointInfo {
     }
 }
 
-impl TransportRtt for EndpointInfo {
+impl Rtt for EndpointInfo {
     fn rtt(&self) -> Duration {
         self.rtt
     }
 }
 
-impl TransportRemoteAddr for EndpointInfo {
+impl RemoteAddr for EndpointInfo {
     fn remote_addr(&self) -> SocketAddr {
         self.remote_addr
     }
@@ -113,7 +113,10 @@ pub struct StreamMessage<S, T> {
     pub msg: T,
 }
 
-impl<S, T> SendOn<S> for StreamMessage<S, T> where S: Clone {
+impl<S, T> SendOn<S> for StreamMessage<S, T>
+where
+    S: Clone,
+{
     fn stream(&self) -> S {
         self.stream.clone()
     }

--- a/aeronet_wt_native/src/transport.rs
+++ b/aeronet_wt_native/src/transport.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, time::Duration};
 
-use aeronet::{SendMessage, TransportRemoteAddr, TransportRtt};
+use aeronet::{TransportRemoteAddr, TransportRtt, TryIntoBytes};
 use anyhow::Result;
 use wtransport::Connection;
 
@@ -113,19 +113,19 @@ pub struct StreamMessage<S, T> {
     pub msg: T,
 }
 
-impl<S: Clone, T: SendMessage> SendOn<S> for StreamMessage<S, T> {
+impl<S, T> SendOn<S> for StreamMessage<S, T> where S: Clone {
     fn stream(&self) -> S {
         self.stream.clone()
     }
 }
 
-impl<S, T> SendMessage for StreamMessage<S, T>
+impl<S, T> TryIntoBytes for StreamMessage<S, T>
 where
-    S: Clone + Send + Sync + 'static,
-    T: SendMessage,
+    S: Clone,
+    T: TryIntoBytes,
 {
-    fn into_payload(self) -> Result<Vec<u8>> {
-        self.msg.into_payload()
+    fn try_into_bytes(self) -> Result<Vec<u8>> {
+        self.msg.try_into_bytes()
     }
 }
 
@@ -138,7 +138,7 @@ pub trait OnStream<S>: Sized {
     fn on(self, stream: S) -> StreamMessage<S, Self>;
 }
 
-impl<S, T: SendMessage> OnStream<S> for T {
+impl<S, T> OnStream<S> for T {
     fn on(self, stream: S) -> StreamMessage<S, Self> {
         StreamMessage { stream, msg: self }
     }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -15,7 +15,7 @@ use crate::{Message, RecvError, SessionError};
 ///
 /// The type parameters allow configuring which types of messages are sent and received by this
 /// transport (see [`Message`]).
-/// 
+///
 /// [`Rtt`]: crate::Rtt
 /// [`RemoteAddr`]: crate::RemoteAddr
 pub trait ClientTransport<C2S: Message, S2C: Message> {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "bevy")]
 pub mod plugin;
 
-use crate::{MessageTypes, RecvError, SessionError};
+use crate::{Message, RecvError, SessionError};
 
 /// A client-to-server layer responsible for sending user messages to the other side.
 ///
@@ -11,11 +11,14 @@ use crate::{MessageTypes, RecvError, SessionError};
 /// Different transport implementations will use different methods to
 /// transport the data across, such as through memory or over a network. This means that a
 /// transport does not necessarily work over the internet! If you want to get details such as
-/// RTT or remote address, see [`crate::TransportRtt`] and [`crate::TransportRemoteAddr`].
+/// RTT or remote address, see [`Rtt`] and [`RemoteAddr`].
 ///
-/// The `C` parameter allows configuring which types of messages are sent and received by this
-/// transport (see [`ClientTransportConfig`]).
-pub trait ClientTransport<M: MessageTypes> {
+/// The type parameters allow configuring which types of messages are sent and received by this
+/// transport (see [`Message`]).
+/// 
+/// [`Rtt`]: crate::Rtt
+/// [`RemoteAddr`]: crate::RemoteAddr
+pub trait ClientTransport<C2S: Message, S2C: Message> {
     /// The info that [`ClientTransport::info`] provides.
     type Info;
 
@@ -40,10 +43,10 @@ pub trait ClientTransport<M: MessageTypes> {
     /// }
     /// # }
     /// ```
-    fn recv(&mut self) -> Result<ClientEvent<M::S2C>, RecvError>;
+    fn recv(&mut self) -> Result<ClientEvent<S2C>, RecvError>;
 
     /// Sends a message to the connected server.
-    fn send(&mut self, msg: impl Into<M::C2S>);
+    fn send(&mut self, msg: impl Into<C2S>);
 
     /// Gets transport info on the current connection.
     ///

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,10 +1,7 @@
 #[cfg(feature = "bevy")]
 pub mod plugin;
 
-use crate::{
-    message::{RecvMessage, SendMessage},
-    transport::{RecvError, SessionError},
-};
+use crate::{MessageTypes, RecvError, SessionError};
 
 /// A client-to-server layer responsible for sending user messages to the other side.
 ///
@@ -18,7 +15,7 @@ use crate::{
 ///
 /// The `C` parameter allows configuring which types of messages are sent and received by this
 /// transport (see [`ClientTransportConfig`]).
-pub trait ClientTransport<C: ClientTransportConfig> {
+pub trait ClientTransport<M: MessageTypes> {
     /// The info that [`ClientTransport::info`] provides.
     type Info;
 
@@ -43,10 +40,10 @@ pub trait ClientTransport<C: ClientTransportConfig> {
     /// }
     /// # }
     /// ```
-    fn recv(&mut self) -> Result<ClientEvent<C::S2C>, RecvError>;
+    fn recv(&mut self) -> Result<ClientEvent<M::S2C>, RecvError>;
 
     /// Sends a message to the connected server.
-    fn send(&mut self, msg: impl Into<C::C2S>);
+    fn send(&mut self, msg: impl Into<M::C2S>);
 
     /// Gets transport info on the current connection.
     ///
@@ -57,57 +54,6 @@ pub trait ClientTransport<C: ClientTransportConfig> {
     fn is_connected(&self) -> bool {
         self.info().is_some()
     }
-}
-
-/// Configures the types used by a client-side transport implementation.
-///
-/// A transport is abstract over the exact message type that it uses, instead letting the user
-/// decide. This trait allows configuring the message types both for:
-/// * client-to-server messages ([`ClientTransportConfig::C2S`])
-///   * the client must be able to serialize these into a payload ([`SendMessage`])
-/// * server-to-client messages ([`ClientTransportConfig::S2C`])
-///   * the client must be able to deserialize these from a payload ([`RecvMessage`])
-///
-/// The types used for C2S and S2C may be different.
-///
-/// # Examples
-///
-/// ```
-/// use aeronet::ClientTransportConfig;
-///
-/// #[derive(Debug, Clone)]
-/// pub enum C2S {
-///     Ping(u64),
-/// }
-/// # impl aeronet::SendMessage for C2S {
-/// #     fn into_payload(self) -> anyhow::Result<Vec<u8>> { unimplemented!() }
-/// # }
-///
-/// #[derive(Debug, Clone)]
-/// pub enum S2C {
-///     Pong(u64),
-/// }
-/// # impl aeronet::RecvMessage for S2C {
-/// #     fn from_payload(buf: &[u8]) -> anyhow::Result<Self> { unimplemented!() }
-/// # }
-///
-/// pub struct AppTransportConfig;
-///
-/// impl ClientTransportConfig for AppTransportConfig {
-///     type C2S = C2S;
-///     type S2C = S2C;
-/// }
-/// ```
-pub trait ClientTransportConfig: Send + Sync + 'static {
-    /// The client-to-server message type.
-    ///
-    /// The client will only send messages of this type, requiring [`SendMessage`].
-    type C2S: SendMessage;
-
-    /// The server-to-client message type.
-    ///
-    /// The client will only receive messages of this type, requiring [`RecvMessage`].
-    type S2C: RecvMessage;
 }
 
 /// An event received from a [`ClientTransport`].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,9 @@ mod transport;
 #[cfg(feature = "bevy-tokio-rt")]
 mod runtime;
 
-pub use client::{ClientEvent, ClientTransport, ClientTransportConfig};
-pub use message::{RecvMessage, SendMessage};
-pub use server::{ClientId, ServerEvent, ServerTransport, ServerTransportConfig};
+pub use client::{ClientEvent, ClientTransport};
+pub use message::{Message, MessageTypes, TryFromBytes, TryIntoBytes};
+pub use server::{ClientId, ServerEvent, ServerTransport};
 pub use transport::{RecvError, SessionError, TransportRemoteAddr, TransportRtt};
 
 #[cfg(feature = "bevy")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,48 +6,6 @@
 //! First, you will need a transport implementation to use. Select one from the list above that
 //! suits your needs. Afterwards, use the [`ClientTransport`] and [`ServerTransport`] traits to
 //! interact with the transport, to do functions such as sending and receiving data.
-#![cfg_attr(
-    feature = "bevy",
-    doc = r##"
-
-# With Bevy
-
-Enable the `bevy` feature flag to enable support for the [`bevy`](https://docs.rs/bevy) game
-engine, allowing you to use the built-in transport plugins and events.
-
-```
-use bevy::prelude::*;
-use aeronet::{ServerTransportConfig, ServerTransportPlugin};
-
-#[derive(Debug, Clone)]
-pub struct AppMessage;
-# impl aeronet::SendMessage for AppMessage {
-#     fn into_payload(self) -> anyhow::Result<Vec<u8>> { unimplemented!() }
-# }
-# impl aeronet::RecvMessage for AppMessage {
-#     fn from_payload(buf: &[u8]) -> anyhow::Result<Self> { unimplemented!() }
-# }
-
-pub struct AppTransportConfig;
-
-impl ServerTransportConfig for AppTransportConfig {
-    type C2S = AppMessage;
-    type S2C = AppMessage;
-}
-
-# fn run<MyTransport>()
-# where
-#     MyTransport: ServerTransport<AppTransportConfig> {
-App::new()
-    .add_plugins((
-        DefaultPlugins,
-        ServerTransportPlugin::<AppTransportConfig, MyTransport>::default(),
-    ))
-    .run();
-# }
-```
-"##
-)]
 //!
 //! [`ClientTransport`]: crate::ClientTransport
 //! [`ServerTransport`]: crate::ServerTransport
@@ -63,9 +21,9 @@ mod transport;
 mod runtime;
 
 pub use client::{ClientEvent, ClientTransport};
-pub use message::{Message, MessageTypes, TryFromBytes, TryIntoBytes};
+pub use message::{Message, TryFromBytes, TryIntoBytes};
 pub use server::{ClientId, ServerEvent, ServerTransport};
-pub use transport::{RecvError, SessionError, TransportRemoteAddr, TransportRtt};
+pub use transport::{RecvError, SessionError, RemoteAddr, Rtt};
 
 #[cfg(feature = "bevy")]
 pub use client::plugin::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ mod runtime;
 pub use client::{ClientEvent, ClientTransport};
 pub use message::{Message, TryFromBytes, TryIntoBytes};
 pub use server::{ClientId, ServerEvent, ServerTransport};
-pub use transport::{RecvError, SessionError, RemoteAddr, Rtt};
+pub use transport::{RecvError, RemoteAddr, Rtt, SessionError};
 
 #[cfg(feature = "bevy")]
 pub use client::plugin::{

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,55 +1,106 @@
 use anyhow::Result;
 
-/// Data that can be sent from the current side to the opposite side.
+/// Configures the types of messages that are sent and received by this side.
 ///
-/// The transport implementation may wish to transport the messages as a byte sequence.
-/// This trait means the message can be converted into this *payload* form, able to be
-/// sent over the wire.
+/// A transport is abstract over the exact message type that it uses, instead letting the user
+/// decide. This trait allows configuring the message types in both the client-to-server and
+/// server-to-client directions. The types used for both may be different or the same.
+/// The types used for C2S and S2C may be different.
 ///
-/// See [`RecvMessage`] for the receiving counterpart.
+/// # Examples
 ///
-/// # Serialization support
+/// ```
+/// use aeronet::TransportConfig;
 ///
-/// With the `bincode` feature enabled, this trait will automatically be implemented for types
-/// which implement `serde::Serialize`.
-pub trait SendMessage: Send + Sync + Clone + 'static {
-    /// Attempts to convert this message into its payload form as bytes.
-    fn into_payload(self) -> Result<Vec<u8>>;
+/// #[derive(Debug, Clone)]
+/// pub enum C2S {
+///     Ping(u64),
+/// }
+/// # impl aeronet::RecvMessage for C2S {
+/// #     fn from_payload(buf: &[u8]) -> anyhow::Result<Self> { unimplemented!() }
+/// # }
+///
+/// #[derive(Debug, Clone)]
+/// pub enum S2C {
+///     Pong(u64),
+/// }
+/// # impl aeronet::SendMessage for S2C {
+/// #     fn into_payload(self) -> anyhow::Result<Vec<u8>> { unimplemented!() }
+/// # }
+///
+/// pub struct AppTransportConfig;
+///
+/// impl ServerTransportConfig for AppTransportConfig {
+///     type C2S = C2S;
+///     type S2C = S2C;
+/// }
+/// ```
+pub trait MessageTypes: Send + Sync + 'static {
+    /// The client-to-server message type.
+    type C2S: Message;
+
+    /// The server-to-client message type.
+    type S2C: Message;
 }
 
-/// Data that can be received from the opposite side by the current side.s
+pub trait Message: Send + Sync + 'static {}
+
+impl<T> Message for T where T: Send + Sync + 'static {}
+
+/// Data that can be potentially converted into a sequence of bytes.
 ///
-/// The transport implementation may wish to receive messages as a byte sequence.
-/// This trait means the message can be deserialized from this *payload* form, able to be
-/// received over the wire.
+/// The transport implementation may wish to handle messages as a byte sequence, for example
+/// if it communicates over a network.
+/// This trait can be used as a bound to ensure that messages can be converted into a byte form.
 ///
-/// See [`SendMessage`] for the sending counterpart.
+/// See [`TryFromBytes`] for the receiving counterpart.
+#[cfg_attr(
+    feature = "bincode",
+    doc = r##"
+
+# [`bincode`] + [`serde`] support
+
+With the `bincode` feature enabled, this trait will automatically be implemented for types which
+implement [`serde::Serialize`].
+"##
+)]
+pub trait TryIntoBytes {
+    /// Performs the conversion.
+    fn try_into_bytes(self) -> Result<Vec<u8>>;
+}
+
+/// Data that can be potentially converted from a sequence of bytes into this type.
 ///
-/// # Serialization support
+/// The transport implementation may wish to handle messages as a byte sequence, for example
+/// if it communicates over a network.
+/// This trait can be used as a bound to ensure that messages can be converted from a byte form.
 ///
-/// With the `bincode` feature enabled, this trait will automatically be implemented for types
-/// which implement `serde::de::DeserializeOwned`.
-pub trait RecvMessage: Send + Sync + Sized + 'static {
-    /// Attempts to convert a payload from a byte buffer into this message.
-    fn from_payload(buf: &[u8]) -> Result<Self>;
+/// See [`TryIntoBytes`] for the sending counterpart.
+#[cfg_attr(
+    feature = "bincode",
+    doc = r##"
+
+# [`bincode`] + [`serde`] support
+
+With the `bincode` feature enabled, this trait will automatically be implemented for types which
+implement [`serde::de::DeserializeOwned`].
+"##
+)]
+pub trait TryFromBytes: Sized {
+    /// Performs the conversion.
+    fn try_from_bytes(buf: &[u8]) -> Result<Self>;
 }
 
 #[cfg(feature = "bincode")]
-impl<T> SendMessage for T
-where
-    T: Send + Sync + Clone + serde::Serialize + 'static,
-{
-    fn into_payload(self) -> Result<Vec<u8>> {
-        bincode::serialize(&self).map_err(|err| err.into())
+impl<T> TryIntoBytes for T where T: serde::Serialize {
+    fn try_into_bytes(self) -> Result<Vec<u8>> {
+        bincode::serialize(&self).map_err(anyhow::Error::new)
     }
 }
 
 #[cfg(feature = "bincode")]
-impl<T> RecvMessage for T
-where
-    T: Send + Sync + Sized + serde::de::DeserializeOwned + 'static,
-{
-    fn from_payload(buf: &[u8]) -> Result<Self> {
-        bincode::deserialize(buf).map_err(|err| err.into())
+impl<T> TryFromBytes for T where T: serde::de::DeserializeOwned {
+    fn try_from_bytes(buf: &[u8]) -> Result<Self> {
+        bincode::deserialize(buf).map_err(anyhow::Error::new)
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 /// Wrapper resource around an async [`tokio`] runtime.
 ///
 /// Some transports may require an async runtime for handling connections, and Bevy does not
-/// provide one by default. This module provides a [`tokio::runtime::Runtime`] wrapped in a
+/// provide one by default. This provides a [`tokio::runtime::Runtime`] wrapped in a
 /// [`Resource`] which can be injected into any system.
 ///
 /// # Usage

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -3,7 +3,7 @@ pub mod plugin;
 
 use std::fmt::Display;
 
-use crate::{MessageTypes, RecvError, SessionError};
+use crate::{Message, RecvError, SessionError};
 
 /// A server-to-client layer responsible for sending user messages to the other side.
 ///
@@ -13,11 +13,18 @@ use crate::{MessageTypes, RecvError, SessionError};
 /// Different transport implementations will use different methods to
 /// transport the data across, such as through memory or over a network. This means that a
 /// transport does not necessarily work over the internet! If you want to get details such as
-/// RTT or remote address, see [`crate::TransportRtt`] and [`crate::TransportRemoteAddr`].
+/// RTT or remote address, see [`Rtt`] and [`RemoteAddr`].
 ///
-/// The `C` parameter allows configuring which types of messages are sent and received by this
-/// transport (see [`ServerTransportConfig`]).
-pub trait ServerTransport<M: MessageTypes> {
+/// The type parameters allows configuring which types of messages are sent and received by this
+/// transport (see [`Message`]).
+/// 
+/// [`Rtt`]: crate::Rtt
+/// [`RemoteAddr`]: crate::RemoteAddr
+pub trait ServerTransport<C2S, S2C>
+where
+    C2S: Message,
+    S2C: Message,
+{
     /// The info that [`ServerTransport::client_info`] provides.
     type ClientInfo;
 
@@ -42,10 +49,10 @@ pub trait ServerTransport<M: MessageTypes> {
     /// }
     /// # }
     /// ```
-    fn recv(&mut self) -> Result<ServerEvent<M::C2S>, RecvError>;
+    fn recv(&mut self) -> Result<ServerEvent<C2S>, RecvError>;
 
     /// Sends a message to a connected client.
-    fn send(&mut self, client: ClientId, msg: impl Into<M::S2C>);
+    fn send(&mut self, client: ClientId, msg: impl Into<S2C>);
 
     /// Forces a client to disconnect from the server.
     ///

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -17,7 +17,7 @@ use crate::{Message, RecvError, SessionError};
 ///
 /// The type parameters allows configuring which types of messages are sent and received by this
 /// transport (see [`Message`]).
-/// 
+///
 /// [`Rtt`]: crate::Rtt
 /// [`RemoteAddr`]: crate::RemoteAddr
 pub trait ServerTransport<C2S, S2C>

--- a/src/server/plugin.rs
+++ b/src/server/plugin.rs
@@ -2,11 +2,9 @@ use std::marker::PhantomData;
 
 use bevy::prelude::*;
 
-use super::{
-    ClientId, RecvError, ServerEvent, ServerTransport, ServerTransportConfig, SessionError,
-};
+use super::{ClientId, MessageTypes, RecvError, ServerEvent, ServerTransport, SessionError};
 
-/// Configures a [`ServerTransport`] of type `T` using configuration `C`.
+/// Configures a [`ServerTransport`] of type `T`.
 ///
 /// This handles receiving data from the transport and forwarding it to the app via events,
 /// as well as sending data to the transport by reading from events. The events provided are:
@@ -53,22 +51,24 @@ use super::{
 /// ```
 #[derive(Debug, derivative::Derivative)]
 #[derivative(Default)]
-pub struct ServerTransportPlugin<C, T> {
-    _phantom_c: PhantomData<C>,
+pub struct ServerTransportPlugin<M, T> {
+    _phantom_m: PhantomData<M>,
     _phantom_t: PhantomData<T>,
 }
 
-impl<C, T> Plugin for ServerTransportPlugin<C, T>
+impl<C2S, S2C, M, T> Plugin for ServerTransportPlugin<M, T>
 where
-    C: ServerTransportConfig,
-    T: ServerTransport<C> + Resource,
+    C2S: Send + Sync + 'static,
+    S2C: Send + Sync + Clone + 'static,
+    M: MessageTypes<C2S = C2S, S2C = S2C>,
+    T: ServerTransport<M> + Resource,
 {
     fn build(&self, app: &mut App) {
         app.add_event::<RemoteClientConnecting>()
             .add_event::<RemoteClientConnected>()
-            .add_event::<FromClient<C::C2S>>()
+            .add_event::<FromClient<C2S>>()
             .add_event::<RemoteClientDisconnected>()
-            .add_event::<ToClient<C::S2C>>()
+            .add_event::<ToClient<S2C>>()
             .add_event::<DisconnectClient>()
             .configure_set(
                 PreUpdate,
@@ -78,8 +78,14 @@ where
                 PostUpdate,
                 ServerTransportSet::Send.run_if(resource_exists::<T>()),
             )
-            .add_systems(PreUpdate, recv::<C, T>.in_set(ServerTransportSet::Recv))
-            .add_systems(PostUpdate, send::<C, T>.in_set(ServerTransportSet::Send));
+            .add_systems(
+                PreUpdate,
+                recv::<C2S, M, T>.in_set(ServerTransportSet::Recv),
+            )
+            .add_systems(
+                PostUpdate,
+                send::<S2C, M, T>.in_set(ServerTransportSet::Send),
+            );
     }
 }
 
@@ -140,16 +146,17 @@ pub struct DisconnectClient {
     pub client: ClientId,
 }
 
-fn recv<C, T>(
+fn recv<C2S, M, T>(
     mut commands: Commands,
     mut server: ResMut<T>,
     mut connecting: EventWriter<RemoteClientConnecting>,
     mut connected: EventWriter<RemoteClientConnected>,
-    mut from_client: EventWriter<FromClient<C::C2S>>,
+    mut from_client: EventWriter<FromClient<C2S>>,
     mut disconnected: EventWriter<RemoteClientDisconnected>,
 ) where
-    C: ServerTransportConfig,
-    T: ServerTransport<C> + Resource,
+    C2S: Send + Sync + 'static,
+    M: MessageTypes<C2S = C2S>,
+    T: ServerTransport<M> + Resource,
 {
     loop {
         match server.recv() {
@@ -174,13 +181,14 @@ fn recv<C, T>(
     }
 }
 
-fn send<C, T>(
+fn send<S2C, M, T>(
     mut server: ResMut<T>,
-    mut to_client: EventReader<ToClient<C::S2C>>,
+    mut to_client: EventReader<ToClient<S2C>>,
     mut disconnect: EventReader<DisconnectClient>,
 ) where
-    C: ServerTransportConfig,
-    T: ServerTransport<C> + Resource,
+    S2C: Send + Sync + Clone + 'static,
+    M: MessageTypes<S2C = S2C>,
+    T: ServerTransport<M> + Resource,
 {
     for ToClient { client, msg } in to_client.iter() {
         server.send(*client, msg.clone());

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -29,7 +29,7 @@ pub enum SessionError {
 }
 
 /// Allows access to the round-trip time of a connection.
-pub trait TransportRtt {
+pub trait Rtt {
     /// Gets the round-trip time to the connected endpoint.
     ///
     /// The round-trip time is defined as the time taken for the following to happen:
@@ -41,7 +41,7 @@ pub trait TransportRtt {
 }
 
 /// Allows access to the remote socket address of the other side of a connection.
-pub trait TransportRemoteAddr {
+pub trait RemoteAddr {
     /// Gets the remote socket address of the endpoint that this side is connected to.
     fn remote_addr(&self) -> SocketAddr;
 }


### PR DESCRIPTION
Use `<C2S, S2C>` instead of `<C: *TransportConfig>` or `<M: MessageTypes>` to make it easier for transport impls to put type bounds on C2S and S2C