### PR TITLE
Improve IO component structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.10.0
+
+- Renamed `Endpoint` to `SessionEndpoint`
+- Added `ServerEndpoint` to mark opening servers
+- Made `Server` only be added to opened servers, and have this component store the
+  `opened_at: Instant`
+- Removed `Opened`
+- All relevant `aeronet_io` types are now registered in the type registry
+
 # 0.9.0
 
 - Redesigned to be Bevy native

--- a/crates/aeronet_channel/src/lib.rs
+++ b/crates/aeronet_channel/src/lib.rs
@@ -3,9 +3,9 @@
 
 use {
     aeronet_io::{
-        AeronetIoPlugin, Endpoint, IoSet, Session,
-        connection::{DROP_DISCONNECT_REASON, Disconnect, DisconnectReason, Disconnected},
+        connection::{Disconnect, DisconnectReason, Disconnected, DROP_DISCONNECT_REASON},
         packet::RecvPacket,
+        AeronetIoPlugin, IoSet, Session, SessionEndpoint,
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, world::Command},
@@ -145,7 +145,7 @@ const MTU: usize = usize::MAX;
 fn on_io_added(trigger: Trigger<OnAdd, ChannelIo>, mut commands: Commands) {
     let entity = trigger.entity();
     let session = Session::new(Instant::now(), MTU);
-    commands.entity(entity).insert((Endpoint, session));
+    commands.entity(entity).insert((SessionEndpoint, session));
 }
 
 fn on_disconnect(trigger: Trigger<Disconnect>, mut sessions: Query<&mut ChannelIo>) {

--- a/crates/aeronet_channel/src/lib.rs
+++ b/crates/aeronet_channel/src/lib.rs
@@ -3,9 +3,9 @@
 
 use {
     aeronet_io::{
-        connection::{Disconnect, DisconnectReason, Disconnected, DROP_DISCONNECT_REASON},
-        packet::RecvPacket,
         AeronetIoPlugin, IoSet, Session, SessionEndpoint,
+        connection::{DROP_DISCONNECT_REASON, Disconnect, DisconnectReason, Disconnected},
+        packet::RecvPacket,
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, world::Command},

--- a/crates/aeronet_io/src/connection.rs
+++ b/crates/aeronet_io/src/connection.rs
@@ -1,7 +1,7 @@
 //! Logic for connection and disconnection of a [`Session`].
 
 use {
-    crate::{Endpoint, Session},
+    crate::{Session, SessionEndpoint},
     bevy_app::prelude::*,
     bevy_derive::Deref,
     bevy_ecs::prelude::*,
@@ -158,7 +158,7 @@ pub struct LocalAddr(pub SocketAddr);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deref, Component)]
 pub struct PeerAddr(pub SocketAddr);
 
-fn on_connecting(trigger: Trigger<OnAdd, Endpoint>) {
+fn on_connecting(trigger: Trigger<OnAdd, SessionEndpoint>) {
     let entity = trigger.entity();
     debug!("{entity} connecting");
 }

--- a/crates/aeronet_io/src/server.rs
+++ b/crates/aeronet_io/src/server.rs
@@ -49,13 +49,13 @@ pub struct ServerEndpoint;
 /// that this does not have to represent a *dedicated* server - you may run
 /// a server, and connect a client to that server, in the same app.
 ///
-/// The server starts in an opening state (when [`Server`] has been added but
-/// [`Opened`] is not yet present), and transitions to either an [`Opened`]
-/// state, or fails to open and is [`Closed`]. After the server is opened, the
-/// server should not close unless there is a fatal server-internal error which
-/// affects all connected clients - if a single client causes issues e.g.
-/// sending illegal data or breaking some invariant, that single client will be
-/// disconnected instead of the entire server being torn down.
+/// The server starts in an opening state (when [`ServerEndpoint`] has been
+/// added but [`Server`] is not yet present), and transitions to either an
+/// opened state, or fails to open and is [`Closed`]. After the server is
+/// opened, the server should not close unless there is a fatal server-internal
+/// error which affects all connected clients - if a single client causes issues
+/// e.g. sending illegal data or breaking some invariant, that single client
+/// will be disconnected instead of the entire server being torn down.
 ///
 /// To listen for when a server is opened, add an observer listening for
 /// [`Trigger<OnAdd, Server>`].
@@ -223,8 +223,8 @@ mod tests {
     use {
         super::*,
         crate::{
-            AeronetIoPlugin,
             connection::{DisconnectReason, Disconnected},
+            AeronetIoPlugin,
         },
         bevy_hierarchy::BuildWorldChildren,
     };

--- a/crates/aeronet_io/src/server.rs
+++ b/crates/aeronet_io/src/server.rs
@@ -78,8 +78,8 @@ pub struct Server {
 impl Server {
     /// Creates a new [`Server`].
     ///
-    /// - `opened_at`: the instant at which the IO layer acknowledged that
-    ///   the server is now ready to accept client connections.
+    /// - `opened_at`: the instant at which the IO layer acknowledged that the
+    ///   server is now ready to accept client connections.
     #[must_use]
     pub const fn new(opened_at: Instant) -> Self {
         Self { opened_at }
@@ -223,8 +223,8 @@ mod tests {
     use {
         super::*,
         crate::{
-            connection::{DisconnectReason, Disconnected},
             AeronetIoPlugin,
+            connection::{DisconnectReason, Disconnected},
         },
         bevy_hierarchy::BuildWorldChildren,
     };

--- a/crates/aeronet_io/src/server.rs
+++ b/crates/aeronet_io/src/server.rs
@@ -22,8 +22,8 @@ pub(crate) struct ServerPlugin;
 
 impl Plugin for ServerPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Server>()
-            .register_type::<Opened>()
+        app.register_type::<ServerEndpoint>()
+            .register_type::<Server>()
             .observe(on_opening)
             .observe(on_opened)
             .observe(on_close)
@@ -31,8 +31,17 @@ impl Plugin for ServerPlugin {
     }
 }
 
-/// Marker component for an [`Entity`] which listens for client connections, and
-/// spawns [`Session`]s to communicate with those clients.
+/// Represents an [`Entity`] which may be preparing to, or has already started,
+/// listening for client connections.
+///
+/// - If a server entity only has [`ServerEndpoint`], it is still opening.
+/// - If a server entity has [`ServerEndpoint`] and [`Server`], it has
+///   successfully opened.
+#[derive(Debug, Component, Reflect)]
+pub struct ServerEndpoint;
+
+/// Represents an [`Entity`] which listens for client connections, and spawns
+/// [`Session`]s to communicate with those clients.
 ///
 /// This represents the "server" part of the client/server networking model (a
 /// client is represented as just a [`Session`]). Its responsibility is to
@@ -48,6 +57,9 @@ impl Plugin for ServerPlugin {
 /// sending illegal data or breaking some invariant, that single client will be
 /// disconnected instead of the entire server being torn down.
 ///
+/// To listen for when a server is opened, add an observer listening for
+/// [`Trigger<OnAdd, Server>`].
+///
 /// When a client connects, it is spawned as a [child] of the server entity.
 /// Therefore, to query for sessions spawned under a server, use
 /// [`Query<Session, With<Parent>>`]. The rest of the connection process is the
@@ -56,30 +68,21 @@ impl Plugin for ServerPlugin {
 ///
 /// [child]: Children
 /// [`Session`]: crate::Session
-#[derive(Debug, Clone, Copy, Default, Component, Reflect)]
-#[reflect(Component)]
-pub struct Server;
-
-/// Component for a [`Server`] which is currently attempting to receive client
-/// connections and spawn [`Session`]s.
-///
-/// To listen for when a server is opened, add an observer listening for
-/// [`Trigger<OnAdd, Opened>`].
-///
-/// [`Session`]: crate::Session
-#[derive(Debug, Clone, Copy, Component, Reflect)]
-#[reflect(Component)]
-pub struct Opened {
-    /// Instant at which the server was opened.
-    pub at: Instant,
+#[derive(Debug, Component, Reflect)]
+#[reflect(from_reflect = false, Component)]
+// TODO: required component `ServerEndpoint`
+pub struct Server {
+    opened_at: Instant,
 }
 
-impl Opened {
-    /// Creates an [`Opened`] which indicates that the server was opened
-    /// [`now`](Instant::now).
+impl Server {
+    /// Creates a new [`Server`].
+    ///
+    /// - `opened_at`: the instant at which the IO layer acknowledged that
+    ///   the server is now ready to accept client connections.
     #[must_use]
-    pub fn now() -> Self {
-        Self { at: Instant::now() }
+    pub const fn new(opened_at: Instant) -> Self {
+        Self { opened_at }
     }
 }
 
@@ -178,12 +181,12 @@ impl<E> From<E> for CloseReason<E> {
     }
 }
 
-fn on_opening(trigger: Trigger<OnAdd, Server>) {
+fn on_opening(trigger: Trigger<OnAdd, ServerEndpoint>) {
     let server = trigger.entity();
     debug!("{server} opening");
 }
 
-fn on_opened(trigger: Trigger<OnAdd, Opened>) {
+fn on_opened(trigger: Trigger<OnAdd, Server>) {
     let server = trigger.entity();
     debug!("{server} opened");
 }
@@ -220,8 +223,8 @@ mod tests {
     use {
         super::*,
         crate::{
-            AeronetIoPlugin,
             connection::{DisconnectReason, Disconnected},
+            AeronetIoPlugin,
         },
         bevy_hierarchy::BuildWorldChildren,
     };

--- a/crates/aeronet_io/src/server.rs
+++ b/crates/aeronet_io/src/server.rs
@@ -223,8 +223,8 @@ mod tests {
     use {
         super::*,
         crate::{
-            connection::{DisconnectReason, Disconnected},
             AeronetIoPlugin,
+            connection::{DisconnectReason, Disconnected},
         },
         bevy_hierarchy::BuildWorldChildren,
     };

--- a/crates/aeronet_replicon/src/client.rs
+++ b/crates/aeronet_replicon/src/client.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::convert,
-    aeronet_io::{Endpoint, Session, connection::Disconnect, web_time::Instant},
+    aeronet_io::{connection::Disconnect, web_time::Instant, Session, SessionEndpoint},
     aeronet_transport::{AeronetTransportPlugin, Transport, TransportSet},
     bevy_app::prelude::*,
     bevy_ecs::prelude::*,
@@ -95,9 +95,9 @@ pub enum ClientTransportSet {
 /// - sending messages
 ///   - all outgoing `replicon` messages are cloned and sent to all sessions
 /// - determining connected status
-///   - if at least 1 session has [`Session`], [`RepliconClient`] is
-///     [`RepliconClientStatus::Connected`]
-///   - if at least 1 session has [`Endpoint`], [`RepliconClient`] is
+///   - if at least 1 session has both [`SessionEndpoint`] and [`Session`],
+///     [`RepliconClient`] is [`RepliconClientStatus::Connected`]
+///   - if at least 1 session has [`SessionEndpoint`], [`RepliconClient`] is
 ///     [`RepliconClientStatus::Connecting`]
 ///   - else, [`RepliconClientStatus::Disconnected`]
 ///
@@ -145,7 +145,7 @@ fn on_client_connected(
 
 fn update_state(
     mut replicon_client: ResMut<RepliconClient>,
-    clients: Query<Option<&Session>, (With<Endpoint>, With<AeronetRepliconClient>)>,
+    clients: Query<Option<&Session>, (With<SessionEndpoint>, With<AeronetRepliconClient>)>,
 ) {
     let status =
         clients.iter().fold(

--- a/crates/aeronet_replicon/src/client.rs
+++ b/crates/aeronet_replicon/src/client.rs
@@ -2,7 +2,7 @@
 
 use {
     crate::convert,
-    aeronet_io::{connection::Disconnect, web_time::Instant, Session, SessionEndpoint},
+    aeronet_io::{Session, SessionEndpoint, connection::Disconnect, web_time::Instant},
     aeronet_transport::{AeronetTransportPlugin, Transport, TransportSet},
     bevy_app::prelude::*,
     bevy_ecs::prelude::*,

--- a/crates/aeronet_replicon/src/server.rs
+++ b/crates/aeronet_replicon/src/server.rs
@@ -3,10 +3,10 @@
 use {
     crate::convert,
     aeronet_io::{
+        Session,
         connection::{DisconnectReason, Disconnected},
         server::{Server, ServerEndpoint},
         web_time::Instant,
-        Session,
     },
     aeronet_transport::{AeronetTransportPlugin, Transport, TransportSet},
     bevy_app::prelude::*,

--- a/crates/aeronet_replicon/src/server.rs
+++ b/crates/aeronet_replicon/src/server.rs
@@ -3,10 +3,10 @@
 use {
     crate::convert,
     aeronet_io::{
-        Session,
         connection::{DisconnectReason, Disconnected},
-        server::{Opened, Server},
+        server::{Server, ServerEndpoint},
         web_time::Instant,
+        Session,
     },
     aeronet_transport::{AeronetTransportPlugin, Transport, TransportSet},
     bevy_app::prelude::*,
@@ -100,7 +100,8 @@ pub enum ServerTransportSet {
 ///   - the child [`Entity`] (which has [`Session`]) is used as the identifier
 ///     for the client which sent/receives the message (see [`convert`])
 /// - determining server [running] status
-///   - if at least 1 server is [`Opened`], [`RepliconServer`] is [running]
+///   - if at least 1 entity has both [`ServerEndpoint`] and [`Server`],
+///     [`RepliconServer`] is [running]
 ///
 /// Although you can only have one [`RepliconServer`] at a time, it actually
 /// makes sense to have multiple [`AeronetRepliconServer`] entities (unlike
@@ -116,7 +117,11 @@ pub enum ServerTransportSet {
 #[reflect(Component)]
 pub struct AeronetRepliconServer;
 
-type OpenedServer = (With<Server>, With<Opened>, With<AeronetRepliconServer>);
+type OpenedServer = (
+    With<ServerEndpoint>,
+    With<Server>,
+    With<AeronetRepliconServer>,
+);
 
 fn update_state(
     mut replicon_server: ResMut<RepliconServer>,

--- a/crates/aeronet_websocket/examples/websocket_client.rs
+++ b/crates/aeronet_websocket/examples/websocket_client.rs
@@ -3,12 +3,12 @@
 
 use {
     aeronet_io::{
-        connection::{Disconnect, DisconnectReason, Disconnected, LocalAddr, PeerAddr},
         Session, SessionEndpoint,
+        connection::{Disconnect, DisconnectReason, Disconnected, LocalAddr, PeerAddr},
     },
     aeronet_websocket::client::{ClientConfig, WebSocketClient, WebSocketClientPlugin},
     bevy::prelude::*,
-    bevy_egui::{egui, EguiContexts, EguiPlugin},
+    bevy_egui::{EguiContexts, EguiPlugin, egui},
     core::mem,
 };
 

--- a/crates/aeronet_websocket/examples/websocket_client.rs
+++ b/crates/aeronet_websocket/examples/websocket_client.rs
@@ -3,12 +3,12 @@
 
 use {
     aeronet_io::{
-        Endpoint, Session,
         connection::{Disconnect, DisconnectReason, Disconnected, LocalAddr, PeerAddr},
+        Session, SessionEndpoint,
     },
     aeronet_websocket::client::{ClientConfig, WebSocketClient, WebSocketClientPlugin},
     bevy::prelude::*,
-    bevy_egui::{EguiContexts, EguiPlugin, egui},
+    bevy_egui::{egui, EguiContexts, EguiPlugin},
     core::mem,
 };
 
@@ -37,7 +37,7 @@ struct SessionUi {
 }
 
 fn on_connecting(
-    trigger: Trigger<OnAdd, Endpoint>,
+    trigger: Trigger<OnAdd, SessionEndpoint>,
     names: Query<&Name>,
     mut ui_state: ResMut<GlobalUi>,
 ) {

--- a/crates/aeronet_websocket/examples/websocket_echo_server.rs
+++ b/crates/aeronet_websocket/examples/websocket_echo_server.rs
@@ -1,6 +1,8 @@
 //! Example server using WebSocket which listens for clients sending strings
 //! and sends back a string reply.
 
+use aeronet_io::server::Server;
+
 cfg_if::cfg_if! {
     if #[cfg(target_family = "wasm")] {
         fn main() {
@@ -11,8 +13,7 @@ cfg_if::cfg_if! {
 use {
     aeronet_io::{
         connection::{DisconnectReason, Disconnected, LocalAddr},
-        server::Opened,
-        Endpoint, Session,
+        SessionEndpoint, Session,
     },
     aeronet_websocket::server::{Identity, ServerConfig, WebSocketServer, WebSocketServerPlugin},
     bevy::{log::LogPlugin, prelude::*},
@@ -42,13 +43,13 @@ fn open_server(mut commands: Commands) {
     commands.spawn_empty().add(WebSocketServer::open(config));
 }
 
-fn on_opened(trigger: Trigger<OnAdd, Opened>, servers: Query<&LocalAddr>) {
+fn on_opened(trigger: Trigger<OnAdd, Server>, servers: Query<&LocalAddr>) {
     let server = trigger.entity();
     let local_addr = servers.get(server).expect("opened server should have a binding socket `LocalAddr`");
     info!("{server} opened on {}", **local_addr);
 }
 
-fn on_connecting(trigger: Trigger<OnAdd, Endpoint>, clients: Query<&Parent>) {
+fn on_connecting(trigger: Trigger<OnAdd, SessionEndpoint>, clients: Query<&Parent>) {
     let client = trigger.entity();
     let Ok(server) = clients.get(client).map(Parent::get) else {
         return;

--- a/crates/aeronet_websocket/src/client/mod.rs
+++ b/crates/aeronet_websocket/src/client/mod.rs
@@ -4,18 +4,18 @@ mod backend;
 
 use {
     crate::{
-        session::{self, SessionError, SessionFrontend, WebSocketIo, WebSocketSessionPlugin, MTU},
         WebSocketRuntime,
+        session::{self, MTU, SessionError, SessionFrontend, WebSocketIo, WebSocketSessionPlugin},
     },
     aeronet_io::{
-        connection::{DisconnectReason, Disconnected},
         IoSet, Session, SessionEndpoint,
+        connection::{DisconnectReason, Disconnected},
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, system::EntityCommand},
     derive_more::{Display, Error, From},
     futures::{channel::oneshot, never::Never},
-    tracing::{debug_span, Instrument},
+    tracing::{Instrument, debug_span},
     web_time::Instant,
 };
 

--- a/crates/aeronet_websocket/src/client/mod.rs
+++ b/crates/aeronet_websocket/src/client/mod.rs
@@ -4,18 +4,18 @@ mod backend;
 
 use {
     crate::{
+        session::{self, SessionError, SessionFrontend, WebSocketIo, WebSocketSessionPlugin, MTU},
         WebSocketRuntime,
-        session::{self, MTU, SessionError, SessionFrontend, WebSocketIo, WebSocketSessionPlugin},
     },
     aeronet_io::{
-        Endpoint, IoSet, Session,
         connection::{DisconnectReason, Disconnected},
+        IoSet, Session, SessionEndpoint,
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, system::EntityCommand},
     derive_more::{Display, Error, From},
     futures::{channel::oneshot, never::Never},
-    tracing::{Instrument, debug_span},
+    tracing::{debug_span, Instrument},
     web_time::Instant,
 };
 
@@ -132,7 +132,7 @@ fn connect(session: Entity, world: &mut World, config: ClientConfig, target: Con
     );
 
     world.entity_mut(session).insert((
-        Endpoint, // TODO: required component of WebSocketClient
+        SessionEndpoint, // TODO: required component of WebSocketClient
         WebSocketClient(ClientFrontend::Connecting { recv_dc, recv_next }),
     ));
 }

--- a/crates/aeronet_websocket/src/server/mod.rs
+++ b/crates/aeronet_websocket/src/server/mod.rs
@@ -3,26 +3,26 @@
 mod backend;
 mod config;
 
-use aeronet_io::server::ServerEndpoint;
 pub use config::*;
 use {
     crate::{
+        WebSocketRuntime,
         session::{self, SessionError, SessionFrontend, WebSocketIo, WebSocketSessionPlugin},
-        tungstenite, WebSocketRuntime,
+        tungstenite,
     },
     aeronet_io::{
-        connection::{DisconnectReason, Disconnected, LocalAddr, PeerAddr},
-        server::{CloseReason, Closed, Server},
         IoSet, SessionEndpoint,
+        connection::{DisconnectReason, Disconnected, LocalAddr, PeerAddr},
+        server::{CloseReason, Closed, Server, ServerEndpoint},
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, system::EntityCommand},
     bevy_hierarchy::BuildChildren,
     core::net::SocketAddr,
-    derive_more::{derive::From, Display, Error},
+    derive_more::{Display, Error, derive::From},
     futures::channel::{mpsc, oneshot},
     std::io,
-    tracing::{debug_span, Instrument},
+    tracing::{Instrument, debug_span},
     web_time::Instant,
 };
 

--- a/crates/aeronet_webtransport/examples/webtransport_client.rs
+++ b/crates/aeronet_webtransport/examples/webtransport_client.rs
@@ -3,16 +3,16 @@
 
 use {
     aeronet_io::{
+        Session, SessionEndpoint,
         connection::{Disconnect, DisconnectReason, Disconnected, LocalAddr, PeerAddr},
         packet::PacketRtt,
-        Session, SessionEndpoint,
     },
     aeronet_webtransport::{
         cert,
         client::{ClientConfig, WebTransportClient, WebTransportClientPlugin},
     },
     bevy::prelude::*,
-    bevy_egui::{egui, EguiContexts, EguiPlugin},
+    bevy_egui::{EguiContexts, EguiPlugin, egui},
     core::mem,
 };
 

--- a/crates/aeronet_webtransport/examples/webtransport_client.rs
+++ b/crates/aeronet_webtransport/examples/webtransport_client.rs
@@ -3,16 +3,16 @@
 
 use {
     aeronet_io::{
-        Endpoint, Session,
         connection::{Disconnect, DisconnectReason, Disconnected, LocalAddr, PeerAddr},
         packet::PacketRtt,
+        Session, SessionEndpoint,
     },
     aeronet_webtransport::{
         cert,
         client::{ClientConfig, WebTransportClient, WebTransportClientPlugin},
     },
     bevy::prelude::*,
-    bevy_egui::{EguiContexts, EguiPlugin, egui},
+    bevy_egui::{egui, EguiContexts, EguiPlugin},
     core::mem,
 };
 
@@ -42,7 +42,7 @@ struct SessionUi {
 }
 
 fn on_connecting(
-    trigger: Trigger<OnAdd, Endpoint>,
+    trigger: Trigger<OnAdd, SessionEndpoint>,
     names: Query<&Name>,
     mut ui_state: ResMut<GlobalUi>,
 ) {

--- a/crates/aeronet_webtransport/examples/webtransport_echo_server.rs
+++ b/crates/aeronet_webtransport/examples/webtransport_echo_server.rs
@@ -1,7 +1,7 @@
 //! Example server using WebTransport which listens for clients sending strings
 //! and sends back a string reply.
 
-use aeronet_io::Session;
+use aeronet_io::{server::Server, Session};
 
 cfg_if::cfg_if! {
     if #[cfg(target_family = "wasm")] {
@@ -13,7 +13,6 @@ cfg_if::cfg_if! {
 use {
     aeronet_io::{
         connection::{DisconnectReason, Disconnected, LocalAddr},
-        server::Opened,
     },
     aeronet_webtransport::{
         cert,
@@ -68,7 +67,7 @@ fn server_config(identity: &wtransport::Identity) -> ServerConfig {
         .build()
 }
 
-fn on_opened(trigger: Trigger<OnAdd, Opened>, servers: Query<&LocalAddr>) {
+fn on_opened(trigger: Trigger<OnAdd, Server>, servers: Query<&LocalAddr>) {
     let server = trigger.entity();
     let local_addr = servers.get(server)
         .expect("spawned session entity should have a name");

--- a/crates/aeronet_webtransport/examples/webtransport_echo_server.rs
+++ b/crates/aeronet_webtransport/examples/webtransport_echo_server.rs
@@ -1,7 +1,7 @@
 //! Example server using WebTransport which listens for clients sending strings
 //! and sends back a string reply.
 
-use aeronet_io::{server::Server, Session};
+use aeronet_io::{Session, server::Server};
 
 cfg_if::cfg_if! {
     if #[cfg(target_family = "wasm")] {

--- a/crates/aeronet_webtransport/src/client/mod.rs
+++ b/crates/aeronet_webtransport/src/client/mod.rs
@@ -6,20 +6,20 @@ use {
     crate::{
         runtime::WebTransportRuntime,
         session::{
-            self, SessionError, SessionMeta, WebTransportIo, WebTransportSessionPlugin, MIN_MTU,
+            self, MIN_MTU, SessionError, SessionMeta, WebTransportIo, WebTransportSessionPlugin,
         },
     },
     aeronet_io::{
+        IoSet, Session, SessionEndpoint,
         connection::{DisconnectReason, Disconnected},
         packet::RecvPacket,
-        IoSet, Session, SessionEndpoint,
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, system::EntityCommand},
     bytes::Bytes,
     derive_more::{Display, Error, From},
     futures::channel::{mpsc, oneshot},
-    tracing::{debug_span, Instrument},
+    tracing::{Instrument, debug_span},
     web_time::Instant,
 };
 

--- a/crates/aeronet_webtransport/src/client/mod.rs
+++ b/crates/aeronet_webtransport/src/client/mod.rs
@@ -6,20 +6,20 @@ use {
     crate::{
         runtime::WebTransportRuntime,
         session::{
-            self, MIN_MTU, SessionError, SessionMeta, WebTransportIo, WebTransportSessionPlugin,
+            self, SessionError, SessionMeta, WebTransportIo, WebTransportSessionPlugin, MIN_MTU,
         },
     },
     aeronet_io::{
-        Endpoint, IoSet, Session,
         connection::{DisconnectReason, Disconnected},
         packet::RecvPacket,
+        IoSet, Session, SessionEndpoint,
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, system::EntityCommand},
     bytes::Bytes,
     derive_more::{Display, Error, From},
     futures::channel::{mpsc, oneshot},
-    tracing::{Instrument, debug_span},
+    tracing::{debug_span, Instrument},
     web_time::Instant,
 };
 
@@ -133,7 +133,7 @@ fn connect(session: Entity, world: &mut World, config: ClientConfig, target: Con
     );
 
     world.entity_mut(session).insert((
-        Endpoint, // TODO: required component of WebTransportClient
+        SessionEndpoint, // TODO: required component of WebTransportClient
         WebTransportClient(ClientFrontend::Connecting { recv_dc, recv_next }),
     ));
 }

--- a/crates/aeronet_webtransport/src/server/mod.rs
+++ b/crates/aeronet_webtransport/src/server/mod.rs
@@ -6,14 +6,14 @@ use {
     crate::{
         runtime::WebTransportRuntime,
         session::{
-            self, SessionError, SessionMeta, WebTransportIo, WebTransportSessionPlugin, MIN_MTU,
+            self, MIN_MTU, SessionError, SessionMeta, WebTransportIo, WebTransportSessionPlugin,
         },
     },
     aeronet_io::{
+        IoSet, Session, SessionEndpoint,
         connection::{DisconnectReason, Disconnected, LocalAddr, PeerAddr},
         packet::{PacketRtt, RecvPacket},
         server::{CloseReason, Closed, Server, ServerEndpoint},
-        IoSet, Session, SessionEndpoint,
     },
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, system::EntityCommand},
@@ -23,7 +23,7 @@ use {
     core::{net::SocketAddr, time::Duration},
     derive_more::{Display, Error, From},
     futures::channel::{mpsc, oneshot},
-    tracing::{debug_span, Instrument},
+    tracing::{Instrument, debug_span},
     web_time::Instant,
     wtransport::error::ConnectionError,
 };

--- a/examples/echo_client/src/main.rs
+++ b/examples/echo_client/src/main.rs
@@ -16,18 +16,19 @@
 use {
     aeronet::{
         io::{
+            Session, SessionEndpoint,
             bytes::Bytes,
             connection::{Disconnect, DisconnectReason, Disconnected},
-            web_time, Session, SessionEndpoint,
+            web_time,
         },
         transport::{
-            lane::{LaneIndex, LaneKind},
             AeronetTransportPlugin, Transport, TransportConfig,
+            lane::{LaneIndex, LaneKind},
         },
     },
     aeronet_websocket::client::{ClientConfig, WebSocketClient, WebSocketClientPlugin},
     bevy::prelude::*,
-    bevy_egui::{egui, EguiContexts, EguiPlugin},
+    bevy_egui::{EguiContexts, EguiPlugin, egui},
     core::mem,
 };
 

--- a/examples/echo_client/src/main.rs
+++ b/examples/echo_client/src/main.rs
@@ -16,19 +16,18 @@
 use {
     aeronet::{
         io::{
-            Endpoint, Session,
             bytes::Bytes,
             connection::{Disconnect, DisconnectReason, Disconnected},
-            web_time,
+            web_time, Session, SessionEndpoint,
         },
         transport::{
-            AeronetTransportPlugin, Transport, TransportConfig,
             lane::{LaneIndex, LaneKind},
+            AeronetTransportPlugin, Transport, TransportConfig,
         },
     },
     aeronet_websocket::client::{ClientConfig, WebSocketClient, WebSocketClientPlugin},
     bevy::prelude::*,
-    bevy_egui::{EguiContexts, EguiPlugin, egui},
+    bevy_egui::{egui, EguiContexts, EguiPlugin},
     core::mem,
 };
 
@@ -134,7 +133,7 @@ fn setup(mut commands: Commands) {
 }
 
 // Observe state change events using `Trigger`s.
-fn on_connecting(trigger: Trigger<OnAdd, Endpoint>, mut sessions: Query<&mut UiState>) {
+fn on_connecting(trigger: Trigger<OnAdd, SessionEndpoint>, mut sessions: Query<&mut UiState>) {
     let entity = trigger.entity();
     let mut ui_state = sessions
         .get_mut(entity)

--- a/examples/echo_server/src/server.rs
+++ b/examples/echo_server/src/server.rs
@@ -1,13 +1,12 @@
 use {
     aeronet::{
         io::{
-            Session,
             bytes::Bytes,
             connection::{DisconnectReason, Disconnected, LocalAddr},
-            server::Opened,
-            web_time,
+            server::Server,
+            web_time, Session,
         },
-        transport::{AeronetTransportPlugin, Transport, lane::LaneKind},
+        transport::{lane::LaneKind, AeronetTransportPlugin, Transport},
     },
     aeronet_websocket::server::{ServerConfig, WebSocketServer, WebSocketServerPlugin},
     bevy::{log::LogPlugin, prelude::*},
@@ -74,7 +73,7 @@ fn setup(mut commands: Commands) {
 }
 
 // Observe state change events using `Trigger`s
-fn on_opened(trigger: Trigger<OnAdd, Opened>, servers: Query<&LocalAddr>) {
+fn on_opened(trigger: Trigger<OnAdd, Server>, servers: Query<&LocalAddr>) {
     let server = trigger.entity();
     let local_addr = servers
         .get(server)

--- a/examples/echo_server/src/server.rs
+++ b/examples/echo_server/src/server.rs
@@ -1,12 +1,13 @@
 use {
     aeronet::{
         io::{
+            Session,
             bytes::Bytes,
             connection::{DisconnectReason, Disconnected, LocalAddr},
             server::Server,
-            web_time, Session,
+            web_time,
         },
-        transport::{lane::LaneKind, AeronetTransportPlugin, Transport},
+        transport::{AeronetTransportPlugin, Transport, lane::LaneKind},
     },
     aeronet_websocket::server::{ServerConfig, WebSocketServer, WebSocketServerPlugin},
     bevy::{log::LogPlugin, prelude::*},

--- a/examples/move_box_client/src/main.rs
+++ b/examples/move_box_client/src/main.rs
@@ -3,12 +3,12 @@
 use {
     aeronet::{
         io::{
-            Endpoint, Session,
             connection::{Disconnect, DisconnectReason, Disconnected},
+            Session, SessionEndpoint,
         },
         transport::{
-            TransportConfig,
             visualizer::{SessionVisualizer, SessionVisualizerPlugin},
+            TransportConfig,
         },
     },
     aeronet_replicon::client::{AeronetRepliconClient, AeronetRepliconClientPlugin},
@@ -18,7 +18,7 @@ use {
         client::{WebTransportClient, WebTransportClientPlugin},
     },
     bevy::{ecs::query::QuerySingleError, prelude::*},
-    bevy_egui::{EguiContexts, EguiPlugin, egui},
+    bevy_egui::{egui, EguiContexts, EguiPlugin},
     bevy_replicon::prelude::*,
     move_box::{GameState, MoveBoxPlugin, PlayerColor, PlayerInput, PlayerPosition},
 };
@@ -78,7 +78,7 @@ fn setup_level(mut commands: Commands) {
 }
 
 fn on_connecting(
-    trigger: Trigger<OnAdd, Endpoint>,
+    trigger: Trigger<OnAdd, SessionEndpoint>,
     names: Query<&Name>,
     mut ui_state: ResMut<GlobalUi>,
 ) {
@@ -103,12 +103,13 @@ fn on_connected(
     ui_state.log.push(format!("{name} connected"));
 
     game_state.set(GameState::Playing);
-    commands
-        .entity(entity)
-        .insert((SessionVisualizer::default(), TransportConfig {
+    commands.entity(entity).insert((
+        SessionVisualizer::default(),
+        TransportConfig {
             max_memory_usage: 64 * 1024,
             send_bytes_per_sec: 4 * 1024,
-        }));
+        },
+    ));
 }
 
 fn on_disconnected(
@@ -140,7 +141,7 @@ fn global_ui(
     mut commands: Commands,
     mut egui: EguiContexts,
     global_ui: Res<GlobalUi>,
-    sessions: Query<(Entity, &Name, Option<&Session>), With<Endpoint>>,
+    sessions: Query<(Entity, &Name, Option<&Session>), With<SessionEndpoint>>,
 ) {
     egui::Window::new("Session Log").show(egui.ctx_mut(), |ui| {
         match sessions.get_single() {

--- a/examples/move_box_client/src/main.rs
+++ b/examples/move_box_client/src/main.rs
@@ -3,12 +3,12 @@
 use {
     aeronet::{
         io::{
-            connection::{Disconnect, DisconnectReason, Disconnected},
             Session, SessionEndpoint,
+            connection::{Disconnect, DisconnectReason, Disconnected},
         },
         transport::{
-            visualizer::{SessionVisualizer, SessionVisualizerPlugin},
             TransportConfig,
+            visualizer::{SessionVisualizer, SessionVisualizerPlugin},
         },
     },
     aeronet_replicon::client::{AeronetRepliconClient, AeronetRepliconClientPlugin},
@@ -18,7 +18,7 @@ use {
         client::{WebTransportClient, WebTransportClientPlugin},
     },
     bevy::{ecs::query::QuerySingleError, prelude::*},
-    bevy_egui::{egui, EguiContexts, EguiPlugin},
+    bevy_egui::{EguiContexts, EguiPlugin, egui},
     bevy_replicon::prelude::*,
     move_box::{GameState, MoveBoxPlugin, PlayerColor, PlayerInput, PlayerPosition},
 };
@@ -103,13 +103,12 @@ fn on_connected(
     ui_state.log.push(format!("{name} connected"));
 
     game_state.set(GameState::Playing);
-    commands.entity(entity).insert((
-        SessionVisualizer::default(),
-        TransportConfig {
+    commands
+        .entity(entity)
+        .insert((SessionVisualizer::default(), TransportConfig {
             max_memory_usage: 64 * 1024,
             send_bytes_per_sec: 4 * 1024,
-        },
-    ));
+        }));
 }
 
 fn on_disconnected(

--- a/examples/move_box_server/src/server.rs
+++ b/examples/move_box_server/src/server.rs
@@ -1,8 +1,8 @@
 use {
     aeronet::io::{
-        Session,
         connection::{DisconnectReason, Disconnected, LocalAddr},
-        server::Opened,
+        server::Server,
+        Session,
     },
     aeronet_replicon::server::{AeronetRepliconServer, AeronetRepliconServerPlugin},
     aeronet_websocket::server::{WebSocketServer, WebSocketServerPlugin},
@@ -147,7 +147,7 @@ fn web_socket_config(args: &Args) -> WebSocketServerConfig {
 // server logic
 //
 
-fn on_opened(trigger: Trigger<OnAdd, Opened>, servers: Query<&LocalAddr>) {
+fn on_opened(trigger: Trigger<OnAdd, Server>, servers: Query<&LocalAddr>) {
     let server = trigger.entity();
     let local_addr = servers
         .get(server)

--- a/examples/move_box_server/src/server.rs
+++ b/examples/move_box_server/src/server.rs
@@ -1,8 +1,8 @@
 use {
     aeronet::io::{
+        Session,
         connection::{DisconnectReason, Disconnected, LocalAddr},
         server::Server,
-        Session,
     },
     aeronet_replicon::server::{AeronetRepliconServer, AeronetRepliconServerPlugin},
     aeronet_websocket::server::{WebSocketServer, WebSocketServerPlugin},


### PR DESCRIPTION
- Renamed `Endpoint` to `SessionEndpoint`
- Added `ServerEndpoint` to mark opening servers
- Made `Server` only be added to opened servers, and have this component store the
  `opened_at: Instant`
- Removed `Opened`
- All relevant `aeronet_io` types are now registered in the type registry