### PR TITLE
Fix `SeqBuf::remove` crash

### DIFF
--- a/crates/aeronet_transport/fuzz/Cargo.lock
+++ b/crates/aeronet_transport/fuzz/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aeronet_io"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -20,7 +20,7 @@ dependencies = [
 
 [[package]]
 name = "aeronet_transport"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aeronet_io",
  "ahash",
@@ -48,6 +48,7 @@ name = "aeronet_transport_fuzz"
 version = "0.0.0"
 dependencies = [
  "aeronet_transport",
+ "arbitrary",
  "libfuzzer-sys",
 ]
 

--- a/crates/aeronet_transport/fuzz/Cargo.toml
+++ b/crates/aeronet_transport/fuzz/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.0.0"
 cargo-fuzz = true
 
 [dependencies]
+arbitrary = "1.4"
 libfuzzer-sys = "0.4"
 
 aeronet_transport = { path = ".." }
@@ -25,16 +26,24 @@ doc = false
 test = false
 
 [[bin]]
-name = "transport_recv"
-path = "fuzz_targets/transport_recv.rs"
+name = "round_trip"
+path = "fuzz_targets/round_trip.rs"
 
 bench = false
 doc = false
 test = false
 
 [[bin]]
-name = "round_trip"
-path = "fuzz_targets/round_trip.rs"
+name = "seq_buf"
+path = "fuzz_targets/seq_buf.rs"
+
+bench = false
+doc = false
+test = false
+
+[[bin]]
+name = "transport_recv"
+path = "fuzz_targets/transport_recv.rs"
 
 bench = false
 doc = false

--- a/crates/aeronet_transport/fuzz/fuzz_targets/seq_buf.rs
+++ b/crates/aeronet_transport/fuzz/fuzz_targets/seq_buf.rs
@@ -1,0 +1,33 @@
+#![no_main]
+
+use {aeronet_transport::seq_buf::SeqBuf, arbitrary::Arbitrary, libfuzzer_sys::fuzz_target};
+
+#[derive(Debug, Arbitrary)]
+enum OpKind {
+    Insert,
+    Remove,
+}
+
+#[derive(Debug, Arbitrary)]
+struct Op {
+    kind: OpKind,
+    key: u16,
+    value: u16,
+}
+
+fuzz_target!(|input: Box<[Op]>| {
+    let mut buf = SeqBuf::<u16, 1024>::new();
+
+    for op in input {
+        match op.kind {
+            OpKind::Insert => {
+                buf.insert(op.key, op.value);
+                let value = buf.get(op.key).unwrap();
+                assert_eq!(op.value, *value);
+            }
+            OpKind::Remove => {
+                buf.remove(op.key);
+            }
+        }
+    }
+});

--- a/crates/aeronet_transport/src/lib.rs
+++ b/crates/aeronet_transport/src/lib.rs
@@ -21,7 +21,7 @@ pub mod visualizer;
 
 pub use aeronet_io as io;
 use {
-    aeronet_io::{IoSet, Session, connection::Disconnect, packet::MtuTooSmall},
+    aeronet_io::{connection::Disconnect, packet::MtuTooSmall, IoSet, Session},
     arbitrary::Arbitrary,
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, schedule::SystemSet},
@@ -36,7 +36,7 @@ use {
     send::TransportSend,
     seq_buf::SeqBuf,
     tracing::warn,
-    typesize::{TypeSize, derive::TypeSize},
+    typesize::{derive::TypeSize, TypeSize},
     web_time::Instant,
 };
 

--- a/crates/aeronet_transport/src/lib.rs
+++ b/crates/aeronet_transport/src/lib.rs
@@ -21,7 +21,7 @@ pub mod visualizer;
 
 pub use aeronet_io as io;
 use {
-    aeronet_io::{connection::Disconnect, packet::MtuTooSmall, IoSet, Session},
+    aeronet_io::{IoSet, Session, connection::Disconnect, packet::MtuTooSmall},
     arbitrary::Arbitrary,
     bevy_app::prelude::*,
     bevy_ecs::{prelude::*, schedule::SystemSet},
@@ -36,7 +36,7 @@ use {
     send::TransportSend,
     seq_buf::SeqBuf,
     tracing::warn,
-    typesize::{derive::TypeSize, TypeSize},
+    typesize::{TypeSize, derive::TypeSize},
     web_time::Instant,
 };
 


### PR DESCRIPTION
Fixes https://github.com/aecsocket/aeronet/issues/19.

Added a fuzz test to find the edge case (it was removing with `key: u16::MAX`), and a unit test for this.