### PR TITLE
Do not warn if the Disconnected entity was already despawned

### DIFF
--- a/crates/aeronet_io/src/connection.rs
+++ b/crates/aeronet_io/src/connection.rs
@@ -208,7 +208,7 @@ fn on_disconnected(trigger: Trigger<Disconnected>, mut commands: Commands) {
         }
     }
 
-    commands.entity(target).despawn();
+    commands.entity(target).try_despawn();
 }
 
 #[cfg(test)]

--- a/crates/aeronet_io/src/server.rs
+++ b/crates/aeronet_io/src/server.rs
@@ -221,7 +221,7 @@ fn on_closed(trigger: Trigger<Closed>, children: Query<&Children>, mut commands:
         }
     }
 
-    commands.entity(target).despawn();
+    commands.entity(target).try_despawn();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In some cases I issue some triggers that despawn the Session entity when Disconnected is added, but before this command completes, which results in a warning.
This PR suppresses warnings if the entity was already despawned