### PR TITLE
Fix WASM build for WebSocket

### DIFF
--- a/crates/aeronet_websocket/src/session/backend.rs
+++ b/crates/aeronet_websocket/src/session/backend.rs
@@ -38,7 +38,7 @@ pub mod wasm {
         let (mut send_dc_reason, recv_dc_reason) = mpsc::channel::<Disconnected>(1);
 
         let (_send_dropped, recv_dropped) = oneshot::channel::<()>();
-        let on_open = Closure::<dyn FnOnce()>::once({
+        let on_open = Closure::once({
             let socket = socket.clone();
             let mut send_dc_reason = send_dc_reason.clone();
             || {


### PR DESCRIPTION
I ran into a WASM build error with aeronet_websocket.
Steps to replicate:
- cargo update
- cargo build --target wasm32-unknown-unknown --features client --example websocket_client

Removing the type hint fixes the build error, works with not updated Cargo.lock too.