### PR TITLE
Fix steam_client example

### DIFF
--- a/crates/aeronet_steam/examples/steam_client.rs
+++ b/crates/aeronet_steam/examples/steam_client.rs
@@ -22,7 +22,7 @@ fn main() -> AppExit {
 
     App::new()
         .insert_resource(SteamworksClient(steam))
-        .add_systems(PreUpdate, |steam: NonSend<SteamworksClient>| {
+        .add_systems(PreUpdate, |steam: Res<SteamworksClient>| {
             steam.run_callbacks();
         })
         .add_plugins((


### PR DESCRIPTION
Related to https://github.com/cBournhonesque/lightyear/pull/1212

The system was changed here to use the SteamworksClient but was only changed from NonSend to Res in the server not the client example.

<img width="918" height="312" alt="Screenshot 2025-09-17 at 17 56 15" src="https://github.com/user-attachments/assets/2899093a-b923-4107-9f65-0d6f87c9b285" />
