### PR TITLE
Use correct ws `on_error` type

### DIFF
--- a/crates/aeronet_websocket/src/session/backend.rs
+++ b/crates/aeronet_websocket/src/session/backend.rs
@@ -15,7 +15,7 @@ pub mod wasm {
         },
         js_sys::Uint8Array,
         wasm_bindgen::{JsCast, prelude::Closure},
-        web_sys::{BinaryType, CloseEvent, ErrorEvent, MessageEvent, WebSocket},
+        web_sys::{BinaryType, CloseEvent, Event, MessageEvent, WebSocket},
     };
 
     #[derive(Debug)]
@@ -82,8 +82,8 @@ pub mod wasm {
             })
         };
 
-        let on_error = Closure::<dyn FnMut(_)>::new(move |event: ErrorEvent| {
-            let err = SessionError::Connection(JsError(event.message()));
+        let on_error = Closure::<dyn FnMut(_)>::new(move |event: Event| {
+            let err = SessionError::Connection(JsError(event.to_string().into()));
             _ = send_dc_reason.try_send(Disconnected::by_error(err));
         });
 


### PR DESCRIPTION
ws `on_error` panics at the moment because it expects an [`ErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent) with a message but actually receives a [generic `Event`](https://developer.mozilla.org/en-US/docs/Web/API/Event) with no message.

<img width="1225" height="501" alt="Screenshot 2025-09-24 at 15 32 32" src="https://github.com/user-attachments/assets/7618edad-236c-4f93-a827-c48dc2bff184" />

https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/error_event#event_type