### PR TITLE
feat(replicon): Make RepliconChannels optional to support ChannelIo usage

### DIFF
--- a/crates/aeronet_replicon/src/client.rs
+++ b/crates/aeronet_replicon/src/client.rs
@@ -121,8 +121,12 @@ fn on_client_connected(
     trigger: On<Add, Session>,
     mut commands: Commands,
     clients: Query<&Session, With<AeronetRepliconClient>>,
-    channels: Res<RepliconChannels>,
+    channels: Option<Res<RepliconChannels>>,
 ) {
+    let Some(channels) = channels else {
+        return;
+    };
+
     let target = trigger.event_target();
     let Ok(session) = clients.get(target) else {
         return;


### PR DESCRIPTION
## Problem
When using `aeronet_replicon` in a project where a session is established via `ChannelIo::open()` (e.g., for a singleplayer mode), the application panics if the `RepliconChannels` resource has not been initialized.
This occurs because the `on_connected` observer requires `Res<RepliconChannels>`.

### Error Log
```
thread 'main' (6395150) panicked at /Users/.../.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/bevy_ecs-0.17.3/src/error/handler.rs:125:1:
Encountered an error in observer `aeronet_replicon::server::on_connected`: Parameter `Res<'_, RepliconChannels>` failed validation: Resource does not exist
If this is an expected state, wrap the parameter in `Option<T>` and handle `None` when it happens, or wrap the parameter in `If<T>` to skip the system when it happens.

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic when applying buffers for system `fos_server::singleplayer::on_singleplayer_starting`!
```


This makes it impossible to use `aeronet_channel` alongside `aeronet_replicon`.

## Solution
This PR makes the `RepliconChannels` resource optional in both the client and server `on_connected` observers.
- **Changed:** `Res<RepliconChannels>` -> `Option<Res<RepliconChannels>>`.
- **Logic:**
   - If `RepliconChannels` exists, the transport is created and configured as before.
   - If it is missing, we simply attach the `ConnectedClient` component to keep the session valid but skip the Replicon-specific transport setup.

Hope this helps!