### PR TITLE
Improve `aeronet_transport::FragmentPayload` ergonomics

### DIFF
--- a/crates/aeronet_io/src/packet.rs
+++ b/crates/aeronet_io/src/packet.rs
@@ -33,6 +33,8 @@
 //!
 //! This value may even be [`usize::MAX`] (if using e.g. MPSC channels). Code
 //! which uses the packet MTU must be resilient to being given any MTU value.
+//! In practice, this means that you should never pre-allocate a buffer of size
+//! `MTU`, since that `MTU` might be [`usize::MAX`].
 //!
 //! A networked transport may choose to use [`IP_MTU`] as a base MTU value,
 //! minus protocol overhead.

--- a/crates/aeronet_replicon/src/server.rs
+++ b/crates/aeronet_replicon/src/server.rs
@@ -177,8 +177,6 @@ fn on_connected(
         }
     };
 
-    log::info!("insert client");
-
     commands.entity(client).insert((
         ConnectedClient {
             max_size: session.mtu(),

--- a/crates/aeronet_transport/fuzz/Cargo.lock
+++ b/crates/aeronet_transport/fuzz/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aeronet_io"
-version = "0.17.2"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "bevy_app",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "aeronet_transport"
-version = "0.17.2"
+version = "0.20.0"
 dependencies = [
  "aeronet_io",
  "arbitrary",
@@ -102,16 +102,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "bevy_app"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e4fc5dfe9d1d9b8233e1878353b5e66a3f5910c2131d3abf68f9a4116b2d433"
+checksum = "def9f41aa5bf9b9dec8beda307a332798609cffb9d44f71005e0cfb45164f2f6"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -128,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9396b256b366a43d7f61d1f230cdab0a512fb4712cbf7d688f3d6fce4c5ea8a"
+checksum = "318ee0532c3da93749859d18f89a889c638fbc56aabac4d866583df7b951d103"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -139,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dd5229dd00d00e70ac6b2fc0a139961252f6ce07d3d268cfcac0da86d5bde4"
+checksum = "c9cf7a3ee41342dd7b5a5d82e200d0e8efb933169247fce853b4ad633d51e87d"
 dependencies = [
  "bevy_ecs_macros",
  "bevy_platform",
@@ -165,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d83bdd2285af4867e76c691406e0a4b55611b583d0c45b6ac7bcec1b45fd48"
+checksum = "908baf585e2ea16bd53ef0da57b69580478af0059d2dbdb4369991ac9794b618"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -177,11 +171,10 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d984f9f8bd0f0d9fb020492a955e641e30e7a425f3588bf346cb3e61fec3c3"
+checksum = "3b147843b81a7ec548876ff97fa7bfdc646ef2567cb465566259237b39664438"
 dependencies = [
- "parking_lot",
  "proc-macro2",
  "quote",
  "syn",
@@ -190,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_platform"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4691af6d7cfd1b5deb2fc926a43a180a546cdc3fe1e5a013fcee60db9bb2c81f"
+checksum = "ec6b36504169b644acd26a5469fd8d371aa6f1d73ee5c01b1b1181ae1cefbf9b"
 dependencies = [
  "critical-section",
  "foldhash",
@@ -209,15 +202,15 @@ dependencies = [
 
 [[package]]
 name = "bevy_ptr"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d24d7906c7de556033168b3485de36c59049fbaef0c2c44c715a23e0329b10"
+checksum = "c7a9329e8dc4e01ced480eeec4902e6d7cb56e56ec37f6fbc4323e5c937290a7"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5472b91928c0f3e4e3988c0d036b00719f19520f53a0c3f8c2af72f00e693c5"
+checksum = "d1dfeb67a9fe4f59003a84f5f99ba6302141c70e926601cbc6abfd4a1eea9ca9"
 dependencies = [
  "assert_type_match",
  "bevy_platform",
@@ -229,6 +222,7 @@ dependencies = [
  "downcast-rs",
  "erased-serde",
  "foldhash",
+ "indexmap",
  "serde",
  "smallvec",
  "thiserror",
@@ -237,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083784255162fa39960aa3cf3c23af0e515db2daa7f2e796ae34df993f4d3f6c"
+checksum = "475f68c93e9cd5f17e9167635c8533a4f388f12d38245a202359e4c2721d87ba"
 dependencies = [
  "bevy_macro_utils",
  "indexmap",
@@ -251,9 +245,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_tasks"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbbfa5a58a16c4228434d3018c23fde3d78dcd76ec5f5b2b482a21f4b158dd3"
+checksum = "384eb04d80aa38664d69988fd30cbbe03e937ecb65c66aa6abe60ce0bca826aa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -268,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32835c3dbe082fbbe7d4f2f37f655073421f2882d4320ac2d59f922474260de4"
+checksum = "b5ef9af4e523195e561074cf60fbfad0f4cb8d1db504855fee3c4ce8896c7244"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -280,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.17.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "789d04f88c764877a4552e07745b402dbc45f5d0545e6d102558f2f1752a1d89"
+checksum = "2111910cd7a4b1e6ce07eaaeb6f68a2c0ea0ca609ed0d0d506e3eb161101435b"
 dependencies = [
  "bevy_platform",
  "disqualified",
@@ -514,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
 dependencies = [
  "hash32",
  "portable-atomic",
@@ -569,16 +563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -610,29 +594,6 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
 
 [[package]]
 name = "pin-project"
@@ -694,15 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "ringbuf"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,12 +670,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -792,9 +738,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -983,70 +929,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/crates/aeronet_transport/fuzz/fuzz_targets/frag_recv.rs
+++ b/crates/aeronet_transport/fuzz/fuzz_targets/frag_recv.rs
@@ -4,17 +4,29 @@ use {
     aeronet_transport::{
         frag::FragmentReceiver,
         packet::{FragmentPosition, MessageSeq},
+        size::MinSize,
     },
     libfuzzer_sys::fuzz_target,
 };
 
-fuzz_target!(|input: (FragmentPosition, &[u8])| {
-    let (position, payload) = input;
+fuzz_target!(|input: (FragmentPosition, MessageSeq, &[u8])| {
+    let (position, msg_seq, payload) = input;
 
-    const MAX_FRAG_LEN: usize = 32;
-    const MEM_LEFT: usize = usize::MAX;
-    const MSG_SEQ: MessageSeq = MessageSeq::new(0);
+    const MAX_FRAG_LEN: MinSize = MinSize(32);
+    // test with 8x the default memory limit
+    // if we set it to `usize`, we can trivially crash the fuzzer
+    // by sending a fragment with a large reported number of fragments
+    const MEM_LEFT: usize = 8 * 4 * 1024 * 1024;
 
     let mut recv = FragmentReceiver::default();
-    _ = recv.reassemble(MAX_FRAG_LEN, MEM_LEFT, MSG_SEQ, position, payload);
+    _ = recv.reassemble(
+        MAX_FRAG_LEN,
+        MEM_LEFT,
+        MessageSeq::new(0),
+        position,
+        payload,
+    );
+
+    let mut recv = FragmentReceiver::default();
+    _ = recv.reassemble(MAX_FRAG_LEN, MEM_LEFT, msg_seq, position, payload);
 });

--- a/crates/aeronet_transport/src/frag.rs
+++ b/crates/aeronet_transport/src/frag.rs
@@ -87,9 +87,8 @@ pub fn split(
         .expect("we check above that there should not be more than `MinSize::MAX` fragments");
 
         let payload = FragmentPayload::new(payload).expect(
-            "`payload` is a chunk of up to `max_frag_len` bytes, \
-                and `max_frag_len` is a `MinSize`, \
-                so `payload` should not be bigger than `MinSize`",
+            "`payload` is a chunk of up to `max_frag_len` bytes, and `max_frag_len` is a \
+             `MinSize`, so `payload` should not be bigger than `MinSize`",
         );
 
         (position, payload)

--- a/crates/aeronet_transport/src/frag.rs
+++ b/crates/aeronet_transport/src/frag.rs
@@ -10,7 +10,7 @@
 
 use {
     crate::{
-        packet::{FragmentPosition, MessageSeq},
+        packet::{FragmentPayload, FragmentPosition, MessageSeq},
         size::MinSize,
     },
     alloc::vec::Vec,
@@ -50,21 +50,20 @@ use {
 ///
 /// Panics if `max_frag_len == 0`.
 ///
-/// Panics if `msg` is too large, and is split into too many fragments for
-/// [`FragmentPosition`] to be able to encode the fragment index.
-///
 /// [last fragment]: FragmentPosition::is_last
 pub fn split(
-    max_frag_len: usize,
+    max_frag_len: MinSize,
     msg: Bytes,
 ) -> Result<
-    impl ExactSizeIterator<Item = (FragmentPosition, Bytes)> + DoubleEndedIterator + FusedIterator,
+    impl ExactSizeIterator<Item = (FragmentPosition, FragmentPayload)>
+    + DoubleEndedIterator
+    + FusedIterator,
     MessageTooBig,
 > {
-    assert!(max_frag_len > 0);
+    assert!(max_frag_len.0 > 0);
 
     let byte_len = msg.len();
-    let iter = msg.byte_chunks(max_frag_len);
+    let iter = msg.byte_chunks(usize::from(max_frag_len));
     let num_frags = iter.len();
 
     let last_index = num_frags.saturating_sub(1);
@@ -86,6 +85,12 @@ pub fn split(
                 .and_then(FragmentPosition::non_last)
         }
         .expect("we check above that there should not be more than `MinSize::MAX` fragments");
+
+        let payload = FragmentPayload::new(payload).expect(
+            "`payload` is a chunk of up to `max_frag_len` bytes, \
+                and `max_frag_len` is a `MinSize`, \
+                so `payload` should not be bigger than `MinSize`",
+        );
 
         (position, payload)
     }))
@@ -237,13 +242,13 @@ impl FragmentReceiver {
     /// [`TransportConfig::max_memory_usage`]: crate::TransportConfig::max_memory_usage
     pub fn reassemble(
         &mut self,
-        max_frag_len: usize,
+        max_frag_len: MinSize,
         mem_left: usize,
         msg_seq: MessageSeq,
         position: FragmentPosition,
         payload: &[u8],
     ) -> Result<Option<Vec<u8>>, ReassembleError> {
-        assert!(max_frag_len > 0);
+        assert!(max_frag_len.0 > 0);
 
         let buf = self.msgs.entry(msg_seq).or_default();
         let frag_index = usize::from(position.index());
@@ -254,7 +259,7 @@ impl FragmentReceiver {
         }
 
         // copy the payload data into the buffer
-        let start = frag_index * max_frag_len;
+        let start = frag_index * usize::from(max_frag_len);
         let end = start + payload.len();
 
         // try to resize buffers to make room for this fragment,
@@ -299,11 +304,11 @@ impl FragmentReceiver {
             }
 
             buf.last_frag_index = Some(frag_index);
-        } else if payload.len() != max_frag_len {
+        } else if payload.len() != usize::from(max_frag_len) {
             return Err(ReassembleError::InvalidPayloadLength {
                 index: frag_index,
                 len: payload.len(),
-                expected: max_frag_len,
+                expected: usize::from(max_frag_len),
             });
         }
         buf.payload[start..end].copy_from_slice(payload);
@@ -341,7 +346,7 @@ mod tests {
 
     #[test]
     fn round_trip() {
-        let max_frag_len = 8;
+        let max_frag_len = MinSize(8);
         let msg = Bytes::from_static(b"hello world! goodbye woorld!");
 
         let mut iter = split(max_frag_len, msg).unwrap();

--- a/crates/aeronet_transport/src/lane.rs
+++ b/crates/aeronet_transport/src/lane.rs
@@ -3,7 +3,7 @@
 //! Packets are not guaranteed to have any guarantees on delivery or ordering -
 //! that is, if you send out a packet, there is no guarantee that:
 //! - the packet will be received by the peer
-//! - the packet will be only be received once
+//! - the packet will only be received once
 //! - packets are received in the same order that they are sent
 //!
 //! (Note that receiving a packet is guaranteed to contain the exact same
@@ -15,8 +15,8 @@
 //! guarantees on:
 //! - reliability - the message is guaranteed to be received by the peer once,
 //!   and only once
-//! - ordering - messages sent on a specific are guaranteed to be received in
-//!   the same order that they are sent
+//! - ordering - messages sent on a specific lane are guaranteed to be received
+//!   in the same order that they are sent
 //!   - note that ordering *between* lanes is *never* guaranteed
 //!
 //! The name "lane" was chosen specifically to avoid ambiguity with:
@@ -27,7 +27,8 @@
 //! If you are using an IO layer which is already reliable-ordered, then even
 //! unreliable-unordered messages will be reliable-ordered. However, in this
 //! situation we still need lanes as they are a part of the protocol - we can't
-//! just ignore them for certain IO layers.
+//! just ignore them for certain IO layers. Lanes send messages, and messages
+//! include extra metadata like their sequence number, which we can't ignore.
 
 use {
     crate::size::MinSize,
@@ -54,9 +55,10 @@ pub enum LaneKind {
     /// require any sort of handshaking to ensure that messages have arrived
     /// from one side to the other.
     ///
-    /// For example, spawning particle effects could be sent as an unreliable
-    /// unordered message, as it is a low-priority message which we don't
-    /// really care much about.
+    /// For example, spawning particle effects in a game could be sent as an
+    /// unreliable unordered message, as we'll probably be OK with losing a few
+    /// of the messages, or if they arrive out of order. They can also be
+    /// discarded if they arrive too late.
     UnreliableUnordered,
     /// Messages are *unreliable* but only messages newer than the last
     /// message will be received.
@@ -71,7 +73,7 @@ pub enum LaneKind {
     /// An example of a message using this lane kind is a player positional
     /// update, sent to the server whenever a client moves in a game world.
     /// Since the game client will constantly be sending positional update
-    /// messages at a high rate, it is OK if a few are lost in transit, as the
+    /// messages at a high rate, it's OK if a few are lost in transit, as the
     /// server will hopefully catch the next messages. However, positional
     /// updates should not make the player go back in time - so any messages
     /// older than the most recent ones are dropped.

--- a/crates/aeronet_transport/src/lib.rs
+++ b/crates/aeronet_transport/src/lib.rs
@@ -252,6 +252,7 @@ impl Transport {
             mtu: min_mtu,
             min: FRAG_OVERHEAD,
         })?;
+        let max_frag_len = MinSize::MAX.min_of(max_frag_len);
         Ok(Self {
             flushed_packets: SeqBuf::new_from_fn(|_| FlushedPacket::new(now)),
             stats: MessageStats::default(),

--- a/crates/aeronet_transport/src/limit.rs
+++ b/crates/aeronet_transport/src/limit.rs
@@ -159,7 +159,7 @@ impl Consume for ConsumeImpl<'_> {
 ///
 /// An item (transport, lane, etc.) may want to limit how many bytes it sends
 /// out in a given time frame, e.g. to enforce a bandwidth limit. One way of
-/// doing this is imposing a limit on bytes sent *per app update*, i.e.
+/// doing this is imposing a limit on bytes sent *per app update*, e.g.
 /// 60,000 bytes per update therefore 3,600,000 bytes per second if the app
 /// runs at 60 updates per second. However, it's a bad idea to tie the app's
 /// update rate to this, since updates may take a variable amount of time to

--- a/crates/aeronet_transport/src/packet/frag.rs
+++ b/crates/aeronet_transport/src/packet/frag.rs
@@ -1,5 +1,5 @@
 use {
-    super::{Fragment, FragmentHeader, FragmentPosition, MessageSeq, PayloadTooLarge},
+    super::{Fragment, FragmentHeader, FragmentPosition, MessageSeq},
     crate::{lane::LaneIndex, size::MinSize},
     core::{convert::Infallible, fmt},
     octs::{
@@ -166,7 +166,7 @@ impl EncodeLen for Fragment {
 }
 
 impl Encode for Fragment {
-    type Error = PayloadTooLarge;
+    type Error = Infallible;
 
     fn encode(&self, mut dst: impl Write) -> Result<(), BufTooShortOr<Self::Error>> {
         dst.write(&self.header)?;

--- a/crates/aeronet_transport/src/packet/mod.rs
+++ b/crates/aeronet_transport/src/packet/mod.rs
@@ -22,7 +22,7 @@
 //! to store the fragments. Instead, the logic looks like:
 //!
 //! ```rust,ignore
-//! fn process_packet(packet: &[u8]) {
+//! fn process_packet(packet: &mut &[u8]) {
 //!     process_header(&mut packet);
 //!     while !packet.is_empty() {
 //!         process_fragment(&mut packet);
@@ -36,7 +36,6 @@ mod header;
 mod payload;
 mod seq;
 
-pub use payload::*;
 use {
     crate::{lane::LaneIndex, size::MinSize},
     bevy_reflect::Reflect,
@@ -170,10 +169,11 @@ pub struct FragmentPosition(MinSize);
 /// On the wire, this is encoded as a varint of how long the payload is, plus
 /// the actual payload.
 ///
-/// The length of the underlying byte buffer must not exceed
-/// [`MinSize::MAX`], or it cannot be encoded.
-#[derive(Debug, Clone, PartialEq, Eq, Deref, DerefMut)]
-pub struct FragmentPayload(pub Bytes);
+/// The length of the underlying byte buffer must be able to fit within a
+/// [`MinSize`] (it must not exceed [`MinSize::MAX`]), or it cannot be
+/// constructed.
+#[derive(Debug, Clone, PartialEq, Eq, Deref)]
+pub struct FragmentPayload(Bytes);
 
 /// Front-loaded [`Fragment`] metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, TypeSize, Reflect)]

--- a/crates/aeronet_transport/src/packet/payload.rs
+++ b/crates/aeronet_transport/src/packet/payload.rs
@@ -1,39 +1,59 @@
 use {
     super::FragmentPayload,
     crate::size::MinSize,
-    derive_more::{Display, Error},
-    octs::{BufError, BufTooShortOr, Decode, Encode, EncodeLen, Read, VarIntTooLarge, Write},
+    core::convert::Infallible,
+    octs::{BufTooShortOr, Bytes, Decode, Encode, EncodeLen, Read, VarIntTooLarge, Write},
 };
 
-/// Attempted to [`Encode`] a [`FragmentPayload`] which was more than
-/// [`MinSize::MAX`] bytes long.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Display, Error)]
-#[display("payload too large - {len} / {} bytes", MinSize::MAX.0)]
-pub struct PayloadTooLarge {
-    /// Length of the [`FragmentPayload`].
-    pub len: usize,
-}
+impl FragmentPayload {
+    /// Creates a new empty [`FragmentPayload`] with no bytes.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(Bytes::new())
+    }
 
-impl BufError for PayloadTooLarge {}
+    /// Creates a new [`FragmentPayload`], validating that its length fits
+    /// within [`MinSize`].
+    ///
+    /// If `bytes.len()` does not fit in a [`MinSize`], returns [`None`].
+    pub fn new(bytes: Bytes) -> Option<Self> {
+        let len = bytes.len();
+        MinSize::try_from(len).map(|_| Self(bytes)).ok()
+    }
+
+    /// Returns the number of bytes contained in this `Bytes`.
+    ///
+    /// This is checked at construction time to fit into a [`MinSize`].
+    #[must_use]
+    pub const fn len(&self) -> MinSize {
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "we check at construction time that `self.0.len()` fits into a `MinSize`"
+        )]
+        MinSize(self.0.len() as u32)
+    }
+
+    /// Returns the number of bytes contained in this `Bytes`, as a [`usize`].
+    ///
+    /// This is checked at construction time to fit into a [`MinSize`].
+    #[must_use]
+    pub const fn len_usize(&self) -> usize {
+        self.len().0 as usize
+    }
+}
 
 impl EncodeLen for FragmentPayload {
     fn encode_len(&self) -> usize {
-        let len_u = self.0.len();
-        let Ok(len) = MinSize::try_from(len_u) else {
-            return 0;
-        };
-        len.encode_len() + len_u
+        let len = self.len();
+        len.encode_len() + usize::from(len)
     }
 }
 
 impl Encode for FragmentPayload {
-    type Error = PayloadTooLarge;
+    type Error = Infallible;
 
     fn encode(&self, mut dst: impl Write) -> Result<(), BufTooShortOr<Self::Error>> {
-        let len = self.0.len();
-        let len = MinSize::try_from(len).map_err(|_| PayloadTooLarge { len })?;
-
-        dst.write(len)?;
+        dst.write(self.len())?;
         dst.write_from(self.0.clone())?;
         Ok(())
     }

--- a/crates/aeronet_transport/src/recv.rs
+++ b/crates/aeronet_transport/src/recv.rs
@@ -479,7 +479,7 @@ mod tests {
                     seq: MessageSeq::new(0),
                     position: FragmentPosition::last(0u16).unwrap(),
                 },
-                payload: FragmentPayload(Bytes::from_static(b"hello world")),
+                payload: FragmentPayload::new(Bytes::from_static(b"hello world")).unwrap(),
             })
             .unwrap();
 

--- a/crates/aeronet_transport/src/send.rs
+++ b/crates/aeronet_transport/src/send.rs
@@ -34,7 +34,7 @@ use {
 /// Allows buffering up messages to be sent on a [`Transport`].
 #[derive(Debug, TypeSize)]
 pub struct TransportSend {
-    pub(crate) max_frag_len: usize,
+    pub(crate) max_frag_len: MinSize,
     pub(crate) lanes: Box<[SendLane]>,
     bytes_bucket: TokenBucket,
     next_packet_seq: PacketSeq,
@@ -58,8 +58,8 @@ pub(crate) struct SentMessage {
 #[derive(Debug, Clone, TypeSize)]
 pub(crate) struct SentFragment {
     position: FragmentPosition,
-    #[typesize(with = Bytes::len)]
-    payload: Bytes,
+    #[typesize(with = FragmentPayload::len_usize)]
+    payload: FragmentPayload,
     #[typesize(with = crate::size::of_instant)]
     sent_at: Instant,
     #[typesize(with = crate::size::of_instant)]
@@ -68,7 +68,7 @@ pub(crate) struct SentFragment {
 
 impl TransportSend {
     pub(crate) fn new(
-        max_frag_len: usize,
+        max_frag_len: MinSize,
         lanes: impl IntoIterator<Item = impl Into<LaneKind>>,
     ) -> Self {
         Self {
@@ -192,8 +192,7 @@ impl TransportSend {
             // packet, it will have no fragment header, so will never be
             // received and acked by the peer - consequently, we will never be
             // told that the peer has acked this message.
-            // even if a message is empty, it's still an important object to
-            // track.
+            // even if a message is empty, its existence is important to track.
             //
             // we also can't just say in the sending logic, "if this message has
             // no frags, just make one up on the spot when sending", because at
@@ -208,7 +207,7 @@ impl TransportSend {
             let frags = if frags.is_empty() {
                 alloc::vec![SentFragment {
                     position: FragmentPosition::ZERO_LAST,
-                    payload: Bytes::new(),
+                    payload: FragmentPayload::empty(),
                     sent_at: now,
                     next_flush_at: now,
                 }]
@@ -484,7 +483,7 @@ fn write_frag_at_path(
             lane: path.lane_index,
             position: sent_frag.position,
         },
-        payload: FragmentPayload(sent_frag.payload.clone()),
+        payload: sent_frag.payload.clone(),
     };
     bytes_left.consume(frag.encode_len()).map_err(drop)?;
     packet
@@ -569,7 +568,7 @@ mod tests {
                     position: FragmentPosition::last(0u16).unwrap(),
                     seq: MessageSeq::new(0),
                 },
-                payload: FragmentPayload(Bytes::from_static(msg))
+                payload: FragmentPayload::new(Bytes::from_static(msg)).unwrap(),
             }
         );
     }

--- a/crates/aeronet_transport/src/size.rs
+++ b/crates/aeronet_transport/src/size.rs
@@ -35,6 +35,20 @@ pub struct MinSize(pub u32);
 impl MinSize {
     /// Largest value that can be represented by this type.
     pub const MAX: Self = Self(u32::MAX);
+
+    /// Returns the smaller of this value and `other`.
+    ///
+    /// Since `self` is a [`MinSize`], even if `other` does not fit in a
+    /// [`MinSize`], the result is guaranteed to fit within a [`MinSize`].
+    #[must_use]
+    pub fn min_of(self, other: usize) -> Self {
+        let min = usize::from(self).min(other);
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "`min(MinSize, n)` is guaranteed to fit within a `MinSize`"
+        )]
+        Self(min as u32)
+    }
 }
 
 impl From<u8> for MinSize {


### PR DESCRIPTION
Currently, when building a message to send out on `aeronet_transport`, we make some fragments and store them, then check at encode-time whether those fragments' payloads fit within `MinSize`. This means that encoding is a fallible operation, when it really shouldn't be - *fragmenting* that message into sendable payloads should be the fallible op. Otherwise, you could "send" a message (buffer it for sending), but then it would be impossible to ever actually send it out.

This is sort of an edge case since nobody would ever make a packet that's greater than `2**32-1` (`MinSize::MAX`) bytes in size, but still.

This PR makes encoding fallible, and makes fragmenting a message (during sending) the fallible part.

Also fixes some random typos and docs improvements.