### PR TITLE
feat: improve SessionRequest event ergonomics

### DIFF
--- a/crates/aeronet/docs/changelog.md
+++ b/crates/aeronet/docs/changelog.md
@@ -1,5 +1,9 @@
 Version changelog.
 
+# 0.22.0
+
+- Changed `SessionRequest` to be an entity event triggered on the server when it receives a new session request, instead of a global event (requiring a global observer)
+
 # 0.21.0
 
 - Update to `bevy_replicon` 0.41.0

--- a/crates/aeronet_steam/examples/steam_server.rs
+++ b/crates/aeronet_steam/examples/steam_server.rs
@@ -39,7 +39,6 @@ fn main() -> AppExit {
         .add_systems(Update, reply)
         .add_observer(on_opened)
         .add_observer(on_closed)
-        .add_observer(on_session_request)
         .add_observer(on_connecting)
         .add_observer(on_connected)
         .add_observer(on_disconnected)
@@ -58,24 +57,27 @@ fn open_server(mut commands: Commands) {
         .queue(SteamNetServer::open(SessionConfig::default(), target));
 }
 
-fn on_opened(trigger: On<Add, Server>, servers: Query<&LocalAddr>) {
+fn on_opened(
+    trigger: On<Add, Server>,
+    servers: Query<&LocalAddr>,
+    mut commands: Commands,
+) {
     let server = trigger.event_target();
     if let Ok(local_addr) = servers.get(server) {
         info!("{server} opened on {:?}", **local_addr);
     } else {
         info!("{server} opened for peer connections");
     }
+    commands.entity(server).observe(on_session_request);
 }
 
 fn on_closed(trigger: On<Closed>) {
     panic!("server closed: {:?}", trigger.event());
 }
 
-fn on_session_request(mut request: On<SessionRequest>, clients: Query<&ChildOf>) {
-    let client = request.event_target();
-    let Ok(&ChildOf(server)) = clients.get(client) else {
-        return;
-    };
+fn on_session_request(mut request: On<SessionRequest>) {
+    let server = request.event_target();
+    let client = request.session_entity;
 
     info!(
         "{client} connecting to {server} with Steam ID {:?}",

--- a/crates/aeronet_steam/src/server.rs
+++ b/crates/aeronet_steam/src/server.rs
@@ -265,7 +265,7 @@ impl SessionResponse {
 #[derive(Debug, EntityEvent)]
 pub struct SessionRequest {
     #[event_target]
-    /// [`Opened`] server entity receiving the request to connect.
+    /// [`Server`] entity receiving the request to connect.
     pub server_entity: Entity,
     /// [`Session`] client entity requesting to connect.
     pub session_entity: Entity,

--- a/crates/aeronet_steam/src/server.rs
+++ b/crates/aeronet_steam/src/server.rs
@@ -234,7 +234,8 @@ impl SessionResponse {
 /// };
 ///
 /// fn on_session_request(mut trigger: On<SessionRequest>) {
-///     let client = trigger.event_target();
+///     let server = trigger.event_target();
+///     let session = trigger.session_entity;
 ///     trigger.respond(SessionResponse::Accepted);
 /// }
 /// ```
@@ -263,8 +264,11 @@ impl SessionResponse {
 /// ```
 #[derive(Debug, EntityEvent)]
 pub struct SessionRequest {
+    #[event_target]
+    /// [`Opened`] server entity receiving the request to connect.
+    pub server_entity: Entity,
     /// [`Session`] client entity requesting to connect.
-    pub entity: Entity,
+    pub session_entity: Entity,
     /// Steam ID of the client requesting to connect.
     pub steam_id: SteamId,
     #[debug(skip)]
@@ -418,7 +422,8 @@ fn on_connecting(
     entry.insert(client);
 
     commands.trigger(SessionRequest {
-        entity: client,
+        server_entity: server,
+        session_entity: client,
         steam_id,
         request: Some(request),
     });

--- a/crates/aeronet_webtransport/examples/webtransport_server.rs
+++ b/crates/aeronet_webtransport/examples/webtransport_server.rs
@@ -36,7 +36,6 @@ fn main() -> AppExit {
         .add_systems(Update, reply)
         .add_observer(on_opened)
         .add_observer(on_closed)
-        .add_observer(on_session_request)
         .add_observer(on_connected)
         .add_observer(on_disconnected)
         .run()
@@ -71,23 +70,26 @@ fn server_config(identity: wtransport::Identity) -> ServerConfig {
         .build()
 }
 
-fn on_opened(trigger: On<Add, Server>, servers: Query<&LocalAddr>) {
+fn on_opened(
+    trigger: On<Add, Server>,
+    servers: Query<&LocalAddr>,
+    mut commands: Commands,
+) {
     let server = trigger.event_target();
     let local_addr = servers
         .get(server)
         .expect("spawned session entity should have a name");
     info!("{server} opened on {}", **local_addr);
+    commands.entity(server).observe(on_session_request);
 }
 
 fn on_closed(trigger: On<Closed>) {
     panic!("server closed: {:?}", trigger.event());
 }
 
-fn on_session_request(mut request: On<SessionRequest>, clients: Query<&ChildOf>) {
-    let client = request.event_target();
-    let Ok(&ChildOf(server)) = clients.get(client) else {
-        return;
-    };
+fn on_session_request(mut request: On<SessionRequest>) {
+    let server = request.event_target();
+    let client = request.session_entity;
 
     info!("{client} connecting to {server} from {} with headers:", request.remote_addr);
     for (header_key, header_value) in &request.headers {

--- a/crates/aeronet_webtransport/src/server/mod.rs
+++ b/crates/aeronet_webtransport/src/server/mod.rs
@@ -166,7 +166,8 @@ pub enum SessionResponse {
 /// };
 ///
 /// fn on_session_request(mut trigger: On<SessionRequest>) {
-///     let client = trigger.event_target();
+///     let server = trigger.event_target();
+///     let session = trigger.session_entity;
 ///     trigger.respond(SessionResponse::Accepted);
 /// }
 /// ```
@@ -194,8 +195,11 @@ pub enum SessionResponse {
 #[derive(Debug, EntityEvent, Reflect)]
 #[reflect(from_reflect = false)]
 pub struct SessionRequest {
+    #[event_target]
+    /// [`Opened`] server entity receiving the request to connect.
+    pub server_entity: Entity,
     /// [`Session`] client entity requesting to connect.
-    pub entity: Entity,
+    pub session_entity: Entity,
     /// `:authority` header.
     pub authority: String,
     /// `:path` header.
@@ -363,7 +367,8 @@ fn poll_opened(
             _ = connecting.tx_session_entity.send(client);
 
             commands.trigger(SessionRequest {
-                entity: client,
+                server_entity: entity,
+                session_entity: client,
                 authority: connecting.authority,
                 path: connecting.path,
                 origin: connecting.origin,

--- a/crates/aeronet_webtransport/src/server/mod.rs
+++ b/crates/aeronet_webtransport/src/server/mod.rs
@@ -196,7 +196,7 @@ pub enum SessionResponse {
 #[reflect(from_reflect = false)]
 pub struct SessionRequest {
     #[event_target]
-    /// [`Opened`] server entity receiving the request to connect.
+    /// [`Server`] entity receiving the request to connect.
     pub server_entity: Entity,
     /// [`Session`] client entity requesting to connect.
     pub session_entity: Entity,

--- a/crates/aeronet_webtransport/tests/connection.rs
+++ b/crates/aeronet_webtransport/tests/connection.rs
@@ -182,7 +182,16 @@ fn ping_pong(
             commands.insert_resource(ClientEntity(client));
         }
 
-        fn on_session_request(mut trigger: On<SessionRequest>) {
+        fn on_session_request(
+            mut trigger: On<SessionRequest>,
+            expected_server: Res<ServerEntity>,
+            clients: Query<&ChildOf>,
+        ) {
+            assert_eq!(trigger.event_target(), expected_server.0);
+            let &ChildOf(server) = clients
+                .get(trigger.session_entity)
+                .expect("requesting client session should have a parent server");
+            assert_eq!(server, expected_server.0);
             assert_ne!(
                 trigger.remote_addr.port(),
                 0,
@@ -232,12 +241,12 @@ fn ping_pong(
             .add_observer(on_add_server_endpoint)
             .add_observer(on_add_server)
             .add_observer(on_add_session_endpoint)
-            .add_observer(on_session_request)
             .add_observer(on_add_session)
             .add_systems(Update, recv_on_session);
 
         let world = app.world_mut();
         let server = world.spawn_empty().id();
+        world.entity_mut(server).observe(on_session_request);
         world.insert_resource(ServerEntity(server));
         WebTransportServer::open(server_config).apply(world.entity_mut(server));
 

--- a/examples/src/bin/move_box_server.rs
+++ b/examples/src/bin/move_box_server.rs
@@ -72,7 +72,6 @@ fn main() -> AppExit {
         ))
         .add_systems(Startup, (open_web_transport_server, open_web_socket_server))
         .add_observer(on_opened)
-        .add_observer(on_session_request)
         .add_observer(on_connected)
         .add_observer(on_disconnected)
         .run()
@@ -122,11 +121,9 @@ fn web_transport_config(identity: wtransport::Identity, args: &Args) -> WebTrans
         .build()
 }
 
-fn on_session_request(mut request: On<SessionRequest>, clients: Query<&ChildOf>) {
-    let client = request.event_target();
-    let Ok(&ChildOf(server)) = clients.get(client) else {
-        return;
-    };
+fn on_session_request(mut request: On<SessionRequest>) {
+    let server = request.event_target();
+    let client = request.session_entity;
 
     info!("{client} connecting to {server} with headers:");
     for (header_key, header_value) in &request.headers {
@@ -161,12 +158,17 @@ fn web_socket_config(args: &Args) -> WebSocketServerConfig {
 // server logic
 //
 
-fn on_opened(trigger: On<Add, Server>, servers: Query<&LocalAddr>) {
+fn on_opened(
+    trigger: On<Add, Server>,
+    servers: Query<&LocalAddr>,
+    mut commands: Commands,
+) {
     let server = trigger.event_target();
     let local_addr = servers
         .get(server)
         .expect("opened server should have a binding socket `LocalAddr`");
     info!("{server} opened on {}", **local_addr);
+    commands.entity(server).observe(on_session_request);
 }
 
 fn on_connected(


### PR DESCRIPTION
Fixes https://github.com/aecsocket/aeronet/issues/79.

Changes `SessionRequest` to be an entity event which is ran on the server for which a session is being requested, allowing consumers to add an observer on the server, rather than requiring a global observer.