### PR TITLE
Make WebSocket rustls provider selectable

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@2a44449ff3410624a0fa2ea073c670e1c9236a40
 
   tombi:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: tombi-toml/setup-tombi@v1
+      - uses: tombi-toml/setup-tombi@9fdb1f12707aafdc140839c60421336d4ae157ea
         with:
-          version: 0.6.30
+          version: 1.2.6
       - run: tombi lint
       - run: tombi fmt --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2
         with:
           components: rustfmt
       - run: cargo +nightly fmt --check
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+      - uses: cargo-bins/cargo-binstall@f21464c976f072485f2ab0743b3337b66911d97f
       - run: cargo binstall --no-confirm cargo-shear
       - run: cargo shear
 
@@ -45,7 +45,7 @@ jobs:
         target: ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           components: clippy
       - uses: ./.github/actions/install-bevy-deps
@@ -64,7 +64,7 @@ jobs:
       RUSTDOCFLAGS: "-Dwarnings --cfg=docsrs_aeronet --cfg=web_sys_unstable_apis ${{ matrix.docflags }}"
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2
         with:
           targets: "wasm32-unknown-unknown"
       - uses: ./.github/actions/install-bevy-deps
@@ -78,7 +78,7 @@ jobs:
         target: ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - uses: ./.github/actions/install-bevy-deps
       - run: cargo check --target '${{ matrix.target }}' --workspace --all-features --all-targets
       - if: matrix.target == 'x86_64-unknown-linux-gnu'
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2
       - uses: ./.github/actions/install-bevy-deps
       - run: cargo install cargo-fuzz
       - run: cd crates/aeronet_transport && cargo +nightly fuzz check
@@ -106,7 +106,7 @@ jobs:
         package: ["aeronet_io", "aeronet_transport", "aeronet_replicon"]
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           targets: thumbv6m-none-eabi
       - uses: ./.github/actions/install-bevy-deps
@@ -130,9 +130,9 @@ jobs:
           - "aeronet_webtransport"
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - uses: ./.github/actions/install-bevy-deps
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f21464c976f072485f2ab0743b3337b66911d97f
       - run: cargo binstall --no-confirm cargo-nextest
       - run: cargo nextest run --package '${{ matrix.package }}' --all-features
 
@@ -141,6 +141,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - uses: ./.github/actions/install-bevy-deps
       - run: cargo test --doc --workspace --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,16 @@
 on:
   pull_request:
     paths:
+      - ".github/workflows/rust.yml"
+      - "Cargo.*"
       - "crates/**"
       - "examples/**"
   push:
     branches:
       - main
     paths:
+      - ".github/workflows/rust.yml"
+      - "Cargo.*"
       - "crates/**"
       - "examples/**"
 
@@ -77,6 +81,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: ./.github/actions/install-bevy-deps
       - run: cargo check --target '${{ matrix.target }}' --workspace --all-features --all-targets
+      - if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: |
+          cargo check --package aeronet_websocket --no-default-features --features client --lib
+          cargo check --package aeronet_websocket --no-default-features --features server --lib
+          cargo check --package aeronet_websocket --no-default-features --features server,self-signed --example websocket_server
+          cargo test --package aeronet_websocket --no-default-features --features client,server,self-signed,rustls/ring --test connection
+          cargo test --package aeronet_websocket --features client,server,rustls/ring --test crypto_provider
 
   check-fuzz:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3146,6 +3146,7 @@ dependencies = [
  "bevy_replicon",
  "cfg-if",
  "clap",
+ "rustls",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,36 @@ keywords = ["bevy", "gamedev", "network"]
 categories = ["game-development", "network-programming"]
 
 [workspace.dependencies]
-aeronet = { path = "crates/aeronet", version = "0.21.0", default-features = false }
+aeronet = {
+  path = "crates/aeronet",
+  version = "0.21.0",
+  default-features = false
+}
 aeronet_channel = { path = "crates/aeronet_channel", version = "0.21.0" }
-aeronet_io = { path = "crates/aeronet_io", version = "0.21.0", default-features = false }
-aeronet_replicon = { path = "crates/aeronet_replicon", version = "0.21.0", default-features = false }
-aeronet_transport = { path = "crates/aeronet_transport", version = "0.21.0", default-features = false }
-aeronet_websocket = { path = "crates/aeronet_websocket", version = "0.21.0", default-features = false }
-aeronet_webtransport = { path = "crates/aeronet_webtransport", version = "0.21.0" }
+aeronet_io = {
+  path = "crates/aeronet_io",
+  version = "0.21.0",
+  default-features = false
+}
+aeronet_replicon = {
+  path = "crates/aeronet_replicon",
+  version = "0.21.0",
+  default-features = false
+}
+aeronet_transport = {
+  path = "crates/aeronet_transport",
+  version = "0.21.0",
+  default-features = false
+}
+aeronet_websocket = {
+  path = "crates/aeronet_websocket",
+  version = "0.21.0",
+  default-features = false
+}
+aeronet_webtransport = {
+  path = "crates/aeronet_webtransport",
+  version = "0.21.0"
+}
 anyhow = { version = "1.0.97", default-features = false }
 arbitrary = { version = "1.3.2", features = ["derive"] }
 base64 = { version = "0.22.1" }
@@ -50,7 +73,11 @@ octs = { version = "1.0.0", default-features = false }
 oneshot = { version = "0.1.11" }
 rcgen = { version = "0.13.1" }
 ringbuf = { version = "0.4.8", default-features = false }
-rustls = { version = "0.23.23", default-features = false, features = ["logging", "std", "tls12"] }
+rustls = {
+  version = "0.23.23",
+  default-features = false,
+  features = ["logging", "std", "tls12"]
+}
 rustls-native-certs = { version = "0.8.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 size_format = { version = "1.0.2" }
@@ -88,7 +115,7 @@ unwrap_used = "warn"
 
 [workspace.lints.rust]
 missing_docs = "warn"
-unexpected_cfgs = { level = "warn", check-cfg = [
-  "cfg(fuzzing)",
-  "cfg(docsrs_aeronet)"
-] }
+unexpected_cfgs = {
+  level = "warn",
+  check-cfg = ["cfg(fuzzing)", "cfg(docsrs_aeronet)"]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ aeronet_channel = { path = "crates/aeronet_channel", version = "0.21.0" }
 aeronet_io = { path = "crates/aeronet_io", version = "0.21.0", default-features = false }
 aeronet_replicon = { path = "crates/aeronet_replicon", version = "0.21.0", default-features = false }
 aeronet_transport = { path = "crates/aeronet_transport", version = "0.21.0", default-features = false }
-aeronet_websocket = { path = "crates/aeronet_websocket", version = "0.21.0" }
+aeronet_websocket = { path = "crates/aeronet_websocket", version = "0.21.0", default-features = false }
 aeronet_webtransport = { path = "crates/aeronet_webtransport", version = "0.21.0" }
 anyhow = { version = "1.0.97", default-features = false }
 arbitrary = { version = "1.3.2", features = ["derive"] }
@@ -50,7 +50,7 @@ octs = { version = "1.0.0", default-features = false }
 oneshot = { version = "0.1.11" }
 rcgen = { version = "0.13.1" }
 ringbuf = { version = "0.4.8", default-features = false }
-rustls = { version = "0.23.23" }
+rustls = { version = "0.23.23", default-features = false, features = ["logging", "std", "tls12"] }
 rustls-native-certs = { version = "0.8.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 size_format = { version = "1.0.2" }
@@ -59,8 +59,8 @@ steamworks = { version = "0.12.2" }
 sync_wrapper = { version = "1.0.1" }
 thousands = { version = "0.2.0" }
 tokio = { version = "1.39.2" }
-tokio-rustls = { version = "0.26.2" }
-tokio-tungstenite = { version = "0.26.2" }
+tokio-rustls = { version = "0.26.2", default-features = false }
+tokio-tungstenite = { version = "0.26.2", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
 typesize = { version = "0.1.14", default-features = false }
 wasm-bindgen = { version = "0.2.101" }

--- a/crates/aeronet/docs/changelog.md
+++ b/crates/aeronet/docs/changelog.md
@@ -3,6 +3,7 @@ Version changelog.
 # 0.22.0
 
 - Changed `SessionRequest` to be an entity event triggered on the server when it receives a new session request, instead of a global event (requiring a global observer)
+- Make `aeronet_websocket`'s rustls crypto provider selectable while keeping AWS-LC enabled by default
 
 # 0.21.0
 

--- a/crates/aeronet/docs/changelog.md
+++ b/crates/aeronet/docs/changelog.md
@@ -3,7 +3,8 @@ Version changelog.
 # 0.22.0
 
 - Changed `SessionRequest` to be an entity event triggered on the server when it receives a new session request, instead of a global event (requiring a global observer)
-- Make `aeronet_websocket`'s rustls crypto provider selectable while keeping AWS-LC enabled by default
+- Made `aeronet_websocket`'s rustls crypto provider selectable while keeping AWS-LC enabled by default
+  - `aeronet_websocket` no longer installs a crypto provider when its plugins are added; applications must install their selected provider themselves when both `ring` and `aws-lc-rs` are enabled (or when the default `aws-lc-rs` feature is disabled), otherwise TLS configuration will panic
 
 # 0.21.0
 

--- a/crates/aeronet_io/Cargo.toml
+++ b/crates/aeronet_io/Cargo.toml
@@ -21,13 +21,16 @@ bevy_ecs = { workspace = true, features = ["bevy_reflect"] }
 bevy_platform = { workspace = true, features = ["alloc"] }
 bevy_reflect = { workspace = true }
 bytes = { workspace = true }
-derive_more = { workspace = true, features = [
-  "add",
-  "add_assign",
-  "deref",
-  "display",
-  "error",
-] }
+derive_more = {
+  workspace = true,
+  features = [
+    "add",
+    "add_assign",
+    "deref",
+    "display",
+    "error",
+  ]
+}
 log = { workspace = true }
 
 [target.'cfg(not(all(target_has_atomic = "8", target_has_atomic = "16", target_has_atomic = "32", target_has_atomic = "64", target_has_atomic = "ptr")))'.dependencies]

--- a/crates/aeronet_steam/Cargo.toml
+++ b/crates/aeronet_steam/Cargo.toml
@@ -31,13 +31,16 @@ bevy_ecs = { workspace = true }
 bevy_platform = { workspace = true }
 blocking = { workspace = true }
 bytes = { workspace = true }
-derive_more = { workspace = true, features = [
-  "debug",
-  "deref",
-  "deref_mut",
-  "display",
-  "error",
-] }
+derive_more = {
+  workspace = true,
+  features = [
+    "debug",
+    "deref",
+    "deref_mut",
+    "display",
+    "error",
+  ]
+}
 oneshot = { workspace = true }
 sync_wrapper = { workspace = true }
 tracing = { workspace = true }

--- a/crates/aeronet_transport/Cargo.toml
+++ b/crates/aeronet_transport/Cargo.toml
@@ -28,15 +28,18 @@ bevy_reflect = { workspace = true }
 bevy_time = { workspace = true }
 bevy_winit = { workspace = true, optional = true }
 bit-vec = { workspace = true }
-derive_more = { workspace = true, features = [
-  "add",
-  "add_assign",
-  "deref",
-  "deref_mut",
-  "display",
-  "error",
-  "from",
-] }
+derive_more = {
+  workspace = true,
+  features = [
+    "add",
+    "add_assign",
+    "deref",
+    "deref_mut",
+    "display",
+    "error",
+    "from",
+  ]
+}
 document-features = { workspace = true, optional = true }
 egui_plot = { workspace = true, optional = true }
 either = { workspace = true }

--- a/crates/aeronet_transport/fuzz/Cargo.toml
+++ b/crates/aeronet_transport/fuzz/Cargo.toml
@@ -18,24 +18,24 @@ path = "fuzz_targets/frag_recv.rs"
 test = false
 
 [[bin]]
+bench = false
+doc = false
 name = "round_trip"
 path = "fuzz_targets/round_trip.rs"
-bench = false
-doc = false
 test = false
 
 [[bin]]
+bench = false
+doc = false
 name = "seq_buf"
 path = "fuzz_targets/seq_buf.rs"
-bench = false
-doc = false
 test = false
 
 [[bin]]
-name = "transport_recv"
-path = "fuzz_targets/transport_recv.rs"
 bench = false
 doc = false
+name = "transport_recv"
+path = "fuzz_targets/transport_recv.rs"
 test = false
 
 [dependencies]

--- a/crates/aeronet_websocket/Cargo.toml
+++ b/crates/aeronet_websocket/Cargo.toml
@@ -31,12 +31,15 @@ bevy_ecs = { workspace = true }
 bevy_platform = { workspace = true }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
-derive_more = { workspace = true, features = [
-  "deref",
-  "deref_mut",
-  "display",
-  "error",
-] }
+derive_more = {
+  workspace = true,
+  features = [
+    "deref",
+    "deref_mut",
+    "display",
+    "error",
+  ]
+}
 document-features = { workspace = true, optional = true }
 futures = { workspace = true }
 tracing = { workspace = true }
@@ -58,13 +61,16 @@ tokio-tungstenite = { workspace = true }
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
-web-sys = { workspace = true, features = [
-  "BinaryType",
-  "CloseEvent",
-  "ErrorEvent",
-  "MessageEvent",
-  "WebSocket",
-] }
+web-sys = {
+  workspace = true,
+  features = [
+    "BinaryType",
+    "CloseEvent",
+    "ErrorEvent",
+    "MessageEvent",
+    "WebSocket",
+  ]
+}
 
 [features]
 default = ["aws-lc-rs", "self-signed"]
@@ -85,7 +91,7 @@ document-features = ["dep:document-features"]
 ## [`rcgen`]: https://docs.rs/rcgen
 self-signed = ["dep:rcgen"]
 ## Enables the `server` module.
-server = ["dep:tokio-rustls", "tokio/net", "tokio-tungstenite/handshake"]
+server = ["dep:tokio-rustls", "tokio-tungstenite/handshake", "tokio/net"]
 
 [lints]
 workspace = true

--- a/crates/aeronet_websocket/Cargo.toml
+++ b/crates/aeronet_websocket/Cargo.toml
@@ -22,7 +22,7 @@ required-features = ["client"]
 [[example]]
 name = "websocket_server"
 path = "examples/websocket_server.rs"
-required-features = ["server"]
+required-features = ["self-signed", "server"]
 
 [dependencies]
 aeronet_io = { workspace = true }
@@ -49,10 +49,10 @@ cfg-if = { workspace = true }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 rcgen = { workspace = true, optional = true }
 rustls = { workspace = true }
-rustls-native-certs = { workspace = true }
+rustls-native-certs = { workspace = true, optional = true }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tokio-rustls = { workspace = true, optional = true }
-tokio-tungstenite = { workspace = true, features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { workspace = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = { workspace = true }
@@ -67,9 +67,17 @@ web-sys = { workspace = true, features = [
 ] }
 
 [features]
-default = ["self-signed"]
+default = ["aws-lc-rs", "self-signed"]
+## Enables the `aws-lc-rs` rustls crypto provider.
+##
+## Applications must install their selected provider before building a TLS configuration if another provider is also enabled.
+aws-lc-rs = ["rustls/aws-lc-rs", "rustls/prefer-post-quantum"]
 ## Enables the `client` module.
-client = []
+client = [
+  "dep:rustls-native-certs",
+  "tokio-tungstenite/connect",
+  "tokio-tungstenite/rustls-tls-native-roots",
+]
 ## Enable this when generating docs.
 document-features = ["dep:document-features"]
 ## Allows generating self-signed server certificates using [`rcgen`].
@@ -77,7 +85,7 @@ document-features = ["dep:document-features"]
 ## [`rcgen`]: https://docs.rs/rcgen
 self-signed = ["dep:rcgen"]
 ## Enables the `server` module.
-server = ["dep:tokio-rustls"]
+server = ["dep:tokio-rustls", "tokio/net", "tokio-tungstenite/handshake"]
 
 [lints]
 workspace = true

--- a/crates/aeronet_websocket/README.md
+++ b/crates/aeronet_websocket/README.md
@@ -5,7 +5,10 @@
 
 This uses [`tokio-tungstenite`] on native targets, and [`web-sys`] on WASM targets, for WebSocket usage. The server implementation is only available on native targets.
 
+AWS-LC is the default [rustls] crypto provider. Applications must install their selected provider before building a TLS configuration if default features are disabled or another provider is also enabled.
+
 [`aeronet_io`]: https://docs.rs/aeronet_io
 [WebSockets]: https://web.dev/articles/websockets-basics
 [`tokio-tungstenite`]: https://docs.rs/tokio-tungstenite
 [`web-sys`]: https://docs.rs/web-sys
+[rustls]: https://docs.rs/rustls

--- a/crates/aeronet_websocket/src/client/config.rs
+++ b/crates/aeronet_websocket/src/client/config.rs
@@ -76,9 +76,13 @@ impl ClientConfigBuilder<WantsConnector> {
     ///
     /// [`with_no_encryption`]: ClientConfigBuilder::with_no_encryption
     pub fn with_no_cert_validation(self) -> ClientConfig {
-        let config = rustls::ClientConfig::builder()
+        let builder = rustls::ClientConfig::builder();
+        let verifier = NoServerVerification {
+            supported_algorithms: builder.crypto_provider().signature_verification_algorithms,
+        };
+        let config = builder
             .dangerous()
-            .with_custom_certificate_verifier(Arc::new(NoServerVerification::default()))
+            .with_custom_certificate_verifier(Arc::new(verifier))
             .with_no_client_auth();
         self.with_tls_config(config)
     }
@@ -144,15 +148,6 @@ impl Default for ClientConfig {
 #[derive(Debug, Clone)]
 struct NoServerVerification {
     supported_algorithms: WebPkiSupportedAlgorithms,
-}
-
-impl Default for NoServerVerification {
-    fn default() -> Self {
-        Self {
-            supported_algorithms: rustls::crypto::aws_lc_rs::default_provider()
-                .signature_verification_algorithms,
-        }
-    }
 }
 
 impl ServerCertVerifier for NoServerVerification {

--- a/crates/aeronet_websocket/src/lib.rs
+++ b/crates/aeronet_websocket/src/lib.rs
@@ -21,6 +21,8 @@ cfg_if::cfg_if! {
         #[cfg(feature = "server")]
         pub mod server;
 
-        pub use {tokio_tungstenite, tokio_tungstenite::tungstenite, rustls, rustls_native_certs};
+        pub use {rustls, tokio_tungstenite, tokio_tungstenite::tungstenite};
+        #[cfg(feature = "client")]
+        pub use rustls_native_certs;
     }
 }

--- a/crates/aeronet_websocket/src/server/config.rs
+++ b/crates/aeronet_websocket/src/server/config.rs
@@ -4,7 +4,6 @@
 use {
     alloc::sync::Arc,
     core::net::{Ipv6Addr, SocketAddr},
-    derive_more::{Display, Error},
     rustls::pki_types::{CertificateDer, PrivateKeyDer},
     tokio_tungstenite::tungstenite::{
         handshake::server::{ErrorResponse, Request, Response},
@@ -313,6 +312,6 @@ impl Identity {
 
 /// Provided a subject alternative name which is not a valid DNS string.
 #[cfg(feature = "self-signed")]
-#[derive(Debug, Display, Error)]
+#[derive(Debug, derive_more::Display, derive_more::Error)]
 #[display("invalid SANs for self-signed certificate")]
 pub struct InvalidSan;

--- a/crates/aeronet_websocket/src/session/mod.rs
+++ b/crates/aeronet_websocket/src/session/mod.rs
@@ -40,20 +40,6 @@ impl Plugin for WebSocketSessionPlugin {
             app.add_plugins(AeronetIoPlugin);
         }
 
-        #[cfg(not(target_family = "wasm"))]
-        {
-            use tracing::debug;
-
-            if rustls::crypto::aws_lc_rs::default_provider()
-                .install_default()
-                .is_ok()
-            {
-                debug!("Installed default `aws-lc-rs` CryptoProvider");
-            } else {
-                debug!("CryptoProvider is already installed");
-            }
-        }
-
         app.init_resource::<WebSocketRuntime>()
             .add_systems(PreUpdate, poll.in_set(IoSystems::Poll))
             .add_systems(PostUpdate, flush.in_set(IoSystems::Flush))

--- a/crates/aeronet_websocket/tests/connection.rs
+++ b/crates/aeronet_websocket/tests/connection.rs
@@ -29,7 +29,6 @@ const PONG: Bytes = Bytes::from_static(b"pong");
 fn connect_unencrypted() {
     const PORT: u16 = 29000;
 
-    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     ping_pong(
         ServerConfig::builder()
             .with_bind_default(PORT)
@@ -44,7 +43,6 @@ fn connect_unencrypted() {
 fn connect_encrypted() {
     const PORT: u16 = 29001;
 
-    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let identity = Identity::self_signed(["127.0.0.1", "::1", "localhost"]).unwrap();
     ping_pong(
         ServerConfig::builder()
@@ -72,7 +70,6 @@ fn open_twice() {
         panic!("server closed: {:?}", trigger.reason);
     }
 
-    _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let identity = Identity::self_signed(["127.0.0.1", "::1", "localhost"]).unwrap();
     let server_config = ServerConfig::builder()
         .with_bind_default(PORT)

--- a/crates/aeronet_websocket/tests/crypto_provider.rs
+++ b/crates/aeronet_websocket/tests/crypto_provider.rs
@@ -1,0 +1,27 @@
+#![expect(missing_docs, reason = "testing")]
+#![cfg(not(target_family = "wasm"))]
+
+use {
+    aeronet_websocket::{
+        client::{ClientConfig, WebSocketClientPlugin},
+        server::{Identity, ServerConfig, WebSocketServerPlugin},
+    },
+    bevy::prelude::App,
+};
+
+#[test]
+fn application_owns_crypto_provider_selection() {
+    let mut app = App::new();
+    app.add_plugins((WebSocketClientPlugin, WebSocketServerPlugin));
+    assert!(rustls::crypto::CryptoProvider::get_default().is_none());
+
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("application should install the first crypto provider");
+
+    _ = ClientConfig::default();
+    let identity = Identity::self_signed(["localhost"]).unwrap();
+    _ = ServerConfig::builder()
+        .with_bind_default(0)
+        .with_identity(identity);
+}

--- a/crates/aeronet_webtransport/Cargo.toml
+++ b/crates/aeronet_webtransport/Cargo.toml
@@ -33,13 +33,16 @@ bevy_platform = { workspace = true }
 bevy_reflect = { workspace = true, features = ["std"] }
 bytes = { workspace = true }
 cfg-if = { workspace = true }
-derive_more = { workspace = true, features = [
-  "debug",
-  "deref",
-  "deref_mut",
-  "display",
-  "error",
-] }
+derive_more = {
+  workspace = true,
+  features = [
+    "debug",
+    "deref",
+    "deref_mut",
+    "display",
+    "error",
+  ]
+}
 document-features = { workspace = true, optional = true }
 futures = { workspace = true }
 tracing = { workspace = true }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-rustls = { workspace = true, features = ["ring"] }
+rustls = { workspace = true, features = ["aws-lc-rs"] }
 
 [lints]
 workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 aeronet = { workspace = true, features = ["visualizer"] }
 aeronet_replicon = { workspace = true, features = ["client", "server"] }
-aeronet_websocket = { workspace = true, features = ["client", "server"] }
+aeronet_websocket = { workspace = true, features = ["client", "self-signed", "server"] }
 aeronet_webtransport = { workspace = true, features = [
   "client",
   "dangerous-configuration",
@@ -23,6 +23,9 @@ bevy_replicon = { workspace = true }
 cfg-if = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+rustls = { workspace = true, features = ["ring"] }
 
 [lints]
 workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,12 +11,18 @@ publish = false
 [dependencies]
 aeronet = { workspace = true, features = ["visualizer"] }
 aeronet_replicon = { workspace = true, features = ["client", "server"] }
-aeronet_websocket = { workspace = true, features = ["client", "self-signed", "server"] }
-aeronet_webtransport = { workspace = true, features = [
-  "client",
-  "dangerous-configuration",
-  "server",
-] }
+aeronet_websocket = {
+  workspace = true,
+  features = ["client", "self-signed", "server"]
+}
+aeronet_webtransport = {
+  workspace = true,
+  features = [
+    "client",
+    "dangerous-configuration",
+    "server",
+  ]
+}
 bevy = { workspace = true }
 bevy_egui = { workspace = true }
 bevy_replicon = { workspace = true }

--- a/examples/src/bin/echo_client.rs
+++ b/examples/src/bin/echo_client.rs
@@ -35,9 +35,9 @@ use {
 
 fn main() -> AppExit {
     #[cfg(not(target_family = "wasm"))]
-    rustls::crypto::ring::default_provider()
+    rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .expect("ring should be the first rustls crypto provider installed");
+        .expect("aws-lc-rs should be the first rustls crypto provider installed");
     App::new()
         .add_plugins((
             DefaultPlugins,

--- a/examples/src/bin/echo_client.rs
+++ b/examples/src/bin/echo_client.rs
@@ -34,6 +34,10 @@ use {
 // Let's set up the app.
 
 fn main() -> AppExit {
+    #[cfg(not(target_family = "wasm"))]
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("ring should be the first rustls crypto provider installed");
     App::new()
         .add_plugins((
             DefaultPlugins,

--- a/examples/src/bin/echo_server.rs
+++ b/examples/src/bin/echo_server.rs
@@ -38,6 +38,9 @@ use {
 // Let's set up the app.
 
 fn main() -> AppExit {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("ring should be the first rustls crypto provider installed");
     App::new()
         .add_plugins((
             // Core Bevy plugins.

--- a/examples/src/bin/echo_server.rs
+++ b/examples/src/bin/echo_server.rs
@@ -38,9 +38,9 @@ use {
 // Let's set up the app.
 
 fn main() -> AppExit {
-    rustls::crypto::ring::default_provider()
+    rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .expect("ring should be the first rustls crypto provider installed");
+        .expect("aws-lc-rs should be the first rustls crypto provider installed");
     App::new()
         .add_plugins((
             // Core Bevy plugins.

--- a/examples/src/bin/move_box_client.rs
+++ b/examples/src/bin/move_box_client.rs
@@ -27,6 +27,10 @@ use {
 };
 
 fn main() -> AppExit {
+    #[cfg(not(target_family = "wasm"))]
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("ring should be the first rustls crypto provider installed");
     App::new()
         .add_plugins((
             // core

--- a/examples/src/bin/move_box_client.rs
+++ b/examples/src/bin/move_box_client.rs
@@ -28,9 +28,9 @@ use {
 
 fn main() -> AppExit {
     #[cfg(not(target_family = "wasm"))]
-    rustls::crypto::ring::default_provider()
+    rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .expect("ring should be the first rustls crypto provider installed");
+        .expect("aws-lc-rs should be the first rustls crypto provider installed");
     App::new()
         .add_plugins((
             // core

--- a/examples/src/bin/move_box_server.rs
+++ b/examples/src/bin/move_box_server.rs
@@ -48,6 +48,9 @@ impl FromWorld for Args {
 }
 
 fn main() -> AppExit {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("ring should be the first rustls crypto provider installed");
     App::new()
         .init_resource::<Args>()
         .add_plugins((

--- a/examples/src/bin/move_box_server.rs
+++ b/examples/src/bin/move_box_server.rs
@@ -48,9 +48,9 @@ impl FromWorld for Args {
 }
 
 fn main() -> AppExit {
-    rustls::crypto::ring::default_provider()
+    rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
-        .expect("ring should be the first rustls crypto provider installed");
+        .expect("aws-lc-rs should be the first rustls crypto provider installed");
     App::new()
         .init_resource::<Args>()
         .add_plugins((


### PR DESCRIPTION
`aeronet_websocket` currently installs AWS-LC when its Bevy plugin is added. That can conflict with applications that already use ring or another rustls provider, since provider selection is process-wide.

This keeps AWS-LC as the default but lets applications disable it and install their own provider before building TLS configs. The patch also makes the client/server feature split explicit and adds CI coverage for providerless, ring-only, and mixed-provider setups.