### PR TITLE
Updates steamworks to 0.13

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: crate-ci/typos@master
+      - uses: crate-ci/typos@2a44449ff3410624a0fa2ea073c670e1c9236a40
 
   tombi:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: tombi-toml/setup-tombi@v1
+      - uses: tombi-toml/setup-tombi@9fdb1f12707aafdc140839c60421336d4ae157ea
         with:
-          version: 0.6.30
+          version: 1.2.6
       - run: tombi lint
       - run: tombi fmt --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,12 +1,16 @@
 on:
   pull_request:
     paths:
+      - ".github/workflows/rust.yml"
+      - "Cargo.*"
       - "crates/**"
       - "examples/**"
   push:
     branches:
       - main
     paths:
+      - ".github/workflows/rust.yml"
+      - "Cargo.*"
       - "crates/**"
       - "examples/**"
 
@@ -19,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2
         with:
           components: rustfmt
       - run: cargo +nightly fmt --check
@@ -28,8 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
+      - uses: cargo-bins/cargo-binstall@f21464c976f072485f2ab0743b3337b66911d97f
       - run: cargo binstall --no-confirm cargo-shear
       - run: cargo shear
 
@@ -41,7 +45,7 @@ jobs:
         target: ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           components: clippy
       - uses: ./.github/actions/install-bevy-deps
@@ -60,11 +64,11 @@ jobs:
       RUSTDOCFLAGS: "-Dwarnings --cfg=docsrs_aeronet --cfg=web_sys_unstable_apis ${{ matrix.docflags }}"
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2
         with:
           targets: "wasm32-unknown-unknown"
       - uses: ./.github/actions/install-bevy-deps
-      - run: cargo +nightly doc --target '${{ matrix.target }}' --workspace --all-features
+      - run: cargo +nightly doc --target '${{ matrix.target }}' --workspace --all-features --no-deps
 
   check:
     runs-on: ubuntu-latest
@@ -74,7 +78,7 @@ jobs:
         target: ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - uses: ./.github/actions/install-bevy-deps
       - run: cargo check --target '${{ matrix.target }}' --workspace --all-features --all-targets
 
@@ -82,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2
       - uses: ./.github/actions/install-bevy-deps
       - run: cargo install cargo-fuzz
       - run: cd crates/aeronet_transport && cargo +nightly fuzz check
@@ -95,7 +99,7 @@ jobs:
         package: ["aeronet_io", "aeronet_transport", "aeronet_replicon"]
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
         with:
           targets: thumbv6m-none-eabi
       - uses: ./.github/actions/install-bevy-deps
@@ -119,9 +123,9 @@ jobs:
           - "aeronet_webtransport"
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - uses: ./.github/actions/install-bevy-deps
-      - uses: cargo-bins/cargo-binstall@main
+      - uses: cargo-bins/cargo-binstall@f21464c976f072485f2ab0743b3337b66911d97f
       - run: cargo binstall --no-confirm cargo-nextest
       - run: cargo nextest run --package '${{ matrix.package }}' --all-features
 
@@ -130,6 +134,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - uses: ./.github/actions/install-bevy-deps
       - run: cargo test --doc --workspace --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6229,9 +6229,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "steamworks"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722f54c70818b8debdc25b18618b77a0a69fa280012c29e7904d32f9136299fc"
+checksum = "5ff29921f6a7e8c85b0c971ec3c42002b9f535e3b8f4358cb22911d43709739a"
 dependencies = [
  "bitflags 2.10.0",
  "paste",
@@ -6241,9 +6241,9 @@ dependencies = [
 
 [[package]]
 name = "steamworks-sys"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42862065c9e685d08cc3d9f6c609d4b46bd9684ec7e9420688eb979213469582"
+checksum = "ae139f051204a4af015d4f0ed3a1f7a51020d03a44c7cf249168c543d88131e9"
 
 [[package]]
 name = "strict-num"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rustls-native-certs = { version = "0.8.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 size_format = { version = "1.0.2" }
 spki = { version = "0.7.3" }
-steamworks = { version = "0.12.2" }
+steamworks = { version = "0.13", features = ["serde"] }
 sync_wrapper = { version = "1.0.1" }
 thousands = { version = "0.2.0" }
 tokio = { version = "1.39.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rustls-native-certs = { version = "0.8.0" }
 serde = { version = "1.0.219", features = ["derive"] }
 size_format = { version = "1.0.2" }
 spki = { version = "0.7.3" }
-steamworks = { version = "0.13", features = ["serde"] }
+steamworks = { version = "0.13.1" }
 sync_wrapper = { version = "1.0.1" }
 thousands = { version = "0.2.0" }
 tokio = { version = "1.39.2" }


### PR DESCRIPTION
My project is using steamworks 0.13 features and lightyear, and now that I have migrated to bevy 0.19, maintaining a vendored fork of this just for the version increase seems a waste of time

There shouldn't be any actual impact on the code 