### PR TITLE
Update to bevy_replicon 0.42.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_replicon"
-version = "0.41.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a25105650eb1b27c6ada888e06bb38ff7e326a94c7c5b4d75fb5aee50c5ae45e"
+checksum = "be0faf3fdbafd7d1d658c1b8f8c05c186764765264c1d8aece2807da7f540853"
 dependencies = [
  "bevy",
  "bitflags 2.10.0",
@@ -5457,7 +5457,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -5494,7 +5494,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6222,16 +6222,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -6606,7 +6596,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -8080,7 +8070,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pki-types",
  "sha2 0.11.0",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.17",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bevy_ecs = { version = "0.19.0", default-features = false }
 bevy_egui = { version = "0.40.0" }
 bevy_platform = { version = "0.19.0", default-features = false }
 bevy_reflect = { version = "0.19.0", default-features = false }
-bevy_replicon = { version = "0.41.0", default-features = false }
+bevy_replicon = { version = "0.42.1", default-features = false }
 bevy_state = { version = "0.19.0", default-features = false }
 bevy_time = { version = "0.19.0", default-features = false }
 bevy_winit = { version = "0.19.0", default-features = false }

--- a/crates/aeronet/docs/changelog.md
+++ b/crates/aeronet/docs/changelog.md
@@ -2,6 +2,7 @@ Version changelog.
 
 # 0.22.0
 
+- Update to `bevy_replicon` 0.42.1
 - Changed `SessionRequest` to be an entity event triggered on the server when it receives a new session request, instead of a global event (requiring a global observer)
 - Made `aeronet_websocket`'s rustls crypto provider selectable while keeping AWS-LC enabled by default
   - `aeronet_websocket` no longer installs a crypto provider when its plugins are added; applications must install their selected provider themselves when both `ring` and `aws-lc-rs` are enabled (or when the default `aws-lc-rs` feature is disabled), otherwise TLS configuration will panic


### PR DESCRIPTION
Updates `bevy_replicon` to 0.42.1.