### PR TITLE
Fix nextest source fallback in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -134,7 +134,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
       - uses: ./.github/actions/install-bevy-deps
       - uses: cargo-bins/cargo-binstall@f21464c976f072485f2ab0743b3337b66911d97f
-      - run: cargo binstall --no-confirm cargo-nextest
+      - run: cargo binstall --no-confirm --locked cargo-nextest
       - run: cargo nextest run --package '${{ matrix.package }}' --all-features
 
   # `cargo nextest` currently doesn't support doctests: <https://nexte.st/#quick-start>


### PR DESCRIPTION
`cargo-binstall` can fall back to compiling from source when a prebuilt nextest binary is unavailable. Nextest requires source installs to use its bundled lockfile and now rejects unlocked installs.

Pass `--locked` through to the fallback `cargo install` invocation. This fixes the failure seen in the `aeronet_webtransport` test job, which occurred before its tests started.

Verified with `cargo binstall --no-confirm --locked --dry-run cargo-nextest`.