### PR TITLE
feat(deps): Adds serde feature to aeronet_steam

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7729,6 +7729,7 @@ checksum = "5ff29921f6a7e8c85b0c971ec3c42002b9f535e3b8f4358cb22911d43709739a"
 dependencies = [
  "bitflags 2.13.1",
  "paste",
+ "serde",
  "steamworks-sys",
  "thiserror 2.0.20",
 ]

--- a/crates/aeronet_steam/Cargo.toml
+++ b/crates/aeronet_steam/Cargo.toml
@@ -58,6 +58,8 @@ steamworks = { workspace = true }
 client = []
 ## Enables the `server` module.
 server = []
+## Enables serde support for Steamworks types.
+serde = ["steamworks/serde"]
 
 [lints]
 workspace = true

--- a/crates/aeronet_steam/Cargo.toml
+++ b/crates/aeronet_steam/Cargo.toml
@@ -56,10 +56,10 @@ steamworks = { workspace = true }
 [features]
 ## Enables the `client` module.
 client = []
-## Enables the `server` module.
-server = []
 ## Enables serde support for Steamworks types.
 serde = ["steamworks/serde"]
+## Enables the `server` module.
+server = []
 
 [lints]
 workspace = true


### PR DESCRIPTION
My project uses aeronet steam plugin but we also serialize steam type, if I dont have the option to enable serde on aeronet_steam we wont be able to connect steam with console to share a session